### PR TITLE
[cmake] set OT_MBEDTLS to OT_EXTERNAL_MBEDTLS at top-level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(OT_PLATFORM_LIB "openthread-${EFR32_PLATFORM}")
 set(OT_PLATFORM "external" CACHE STRING "disable example platforms" FORCE)
 set(OT_BUILTIN_MBEDTLS_MANAGEMENT OFF CACHE BOOL "disable builtin mbedtls management" FORCE)
 set(OT_EXTERNAL_MBEDTLS "silabs-mbedtls" CACHE STRING "use silabs mbedtls" FORCE)
+set(OT_MBEDTLS ${OT_EXTERNAL_MBEDTLS})
 
 add_subdirectory(openthread)
 


### PR DESCRIPTION
This is needed because both `sleepy-demo-mtd` and `sleepy-demo-ftd` link against `${OT_MBEDTLS}`. Without this change, OT_MBEDTLS is not defined in [src/sleepy-demo/CMakeLists.txt](https://github.com/openthread/ot-efr32/blob/main/src/sleepy-demo/CMakeLists.txt)