### PR TITLE
[build] create platform subdir in `build` folder

### DIFF
--- a/script/build
+++ b/script/build
@@ -49,7 +49,7 @@ die()
 
 build()
 {
-    local builddir="${OT_CMAKE_BUILD_DIR:-build}"
+    local builddir="${OT_CMAKE_BUILD_DIR:-build/${platform}}"
 
     mkdir -p "${builddir}"
     cd "${builddir}"
@@ -98,7 +98,7 @@ main()
             OT_CMAKE_NINJA_TARGET+=("sleepy-demo-ftd" "sleepy-demo-mtd")
             ;;
     esac
-    
+
     options+=("$@")
     build -DEFR32_PLATFORM="${platform}" "${options[@]}"
 }


### PR DESCRIPTION
This was previously done in [openthread](https://github.com/openthread/openthread/blob/main/script/cmake-build#L177) and prevents errors that arise when build different platforms consecutively.

For example, building `efr32mg1` then `efr32mg21` will cause the MG21 build to fail because binaries were previously compiled using different floating point formats for MG1 that are incompatible with MG21

```shell
arm-none-eabi/bin/ld: error: ../third_party/silabs/gecko_sdk_suite/v3.1/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a(nvm3_page.o) uses VFP register arguments, bin/ot-ncp-ftd does not
arm-none-eabi/bin/ld: failed to merge target specific data of file ../third_party/silabs/gecko_sdk_suite/v3.1/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a(nvm3_page.o)
```