### PR TITLE
[dependabot] remove `romacdon` from PR reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,4 +40,3 @@ updates:
     open-pull-requests-limit: 1
     reviewers:
       - "lmnotran"
-      - "romacdon"


### PR DESCRIPTION
@romacdon would like to have me be the one approving dependabot PRs. This will save him some email spam