### PR TITLE
[camke] set default package version to git hash of root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,15 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(ot-efr32 VERSION 0.2.0)
 
+include("${PROJECT_SOURCE_DIR}/openthread/etc/cmake/functions.cmake")
+
+set(OT_PACKAGE_VERSION "" CACHE STRING "OpenThread Package Version")
+if(OT_PACKAGE_VERSION STREQUAL "")
+    ot_git_version(OT_PACKAGE_VERSION)
+    message(STATUS "Setting default package version: ${OT_PACKAGE_VERSION}")
+endif()
+message(STATUS "Package Version: ${OT_PACKAGE_VERSION}")
+
 set(EFR32_PLATFORM_VALUES
     "efr32mg1"
     "efr32mg12"


### PR DESCRIPTION
This commit sets the version git hash to this repo, rather than the
openthread repo.