### PR TITLE
[examples] update sleepy-demo-mtd to match behavior in the GSDK implementation

### DIFF
--- a/examples/sleepy-demo/README.md
+++ b/examples/sleepy-demo/README.md
@@ -54,22 +54,22 @@ Done
 
 Pressing button 0 on the MTD toggles between operating as a Minimal End Device (MED) and a Sleepy End Device (SED) with the RX off when idle.
 
-Pressing button 1 on the MTD sends a multicast UDP message containing the string "mtd button". The FTD listens on the multicast address and will toggle LED 0 and display a message in the CLI showing "Message Received: mtd button".
+Pressing button 1 on the MTD sends a multicast UDP message containing the string `mtd button`. The FTD listens on the multicast address and will toggle LED 0 and display a message in the CLI showing `Message Received: mtd button`.
 
 ## 4. Buttons on the FTD
 
-Pressing either button 0 or 1 on the FTD will send a UDP message to the FTD containing the string "ftd button". The MTD must first send a multicast message by pressing the MTD's button 1 so that the FTD knows the address of the MTD to send messages to.
+Pressing either button 0 or 1 on the FTD will send a UDP message to the FTD containing the string `ftd button`. The MTD must first send a multicast message by pressing the MTD's button 1 so that the FTD knows the address of the MTD to send messages to.
 
-This will toggle the state of LED0 on the MTD. If the MTD is operating as a sleepy end device then the MTD polls the parent every 5 seconds for messages and will update the LED state on the next poll.
+This will toggle the state of LED0 on the MTD. If the MTD is operating as a sleepy end device then the MTD polls the parent every 2 seconds for messages and will update the LED state on the next poll.
 
 ## 5. Monitoring power consumption of the MTD
 
 Open the Energy Profiler within Silicon Labs Simplicity Studio. Within the Quick Access menu select Start Energy Capture... and select the MTD device. When operating as a Sleepy End Device with no LEDs on the current should be under 20 microamps with occasional spikes during waking and polling the parent. With the LED on the MTD has a current consumption of approximately 1mA.
 
-When operating as a Minimal End Device with the Rx on Idle observe that the current is in the order of 10ma.
+When operating as a Minimal End Device with the Rx on Idle observe that the current is in the order of 10mA.
 
 With further configuration of GPIOs and peripherals it is possible to reduce the sleepy current consumption further.
 
 ## 6. Notes on sleeping, sleepy callback and interrupts
 
-To allow the EFR32 to enter sleepy mode the application must register a callback with efr32SetSleepCallback. The return value of callback is used to indicate that the application has no further work to do and that it is safe to go into a low power mode. The callback is called with interrupts disabled so should do the minimum required to check if it can sleep.
+To allow the EFR32 to enter sleepy mode the application must register a callback with `efr32SetSleepCallback`. The return value of callback is used to indicate that the application has no further work to do and that it is safe to go into a low power mode. The callback is called with interrupts disabled so should do the minimum required to check if it can sleep.


### PR DESCRIPTION
MTD Changes
- Change link polling period to 2000ms
- Disable mode change upon becoming a child. This is to match the behavior of the Gecko SDK sleepy-demo-mtd app