### PR TITLE
[examples] remove LEDs from sleepy-demo

### DIFF
--- a/examples/sleepy-demo/README.md
+++ b/examples/sleepy-demo/README.md
@@ -54,17 +54,15 @@ Done
 
 Pressing button 0 on the MTD toggles between operating as a Minimal End Device (MED) and a Sleepy End Device (SED) with the RX off when idle.
 
-Pressing button 1 on the MTD sends a multicast UDP message containing the string `mtd button`. The FTD listens on the multicast address and will toggle LED 0 and display a message in the CLI showing `Message Received: mtd button`.
+Pressing button 1 on the MTD sends a multicast UDP message containing the string `mtd button`. The FTD listens on the multicast address and will display `Message Received: mtd button` in the CLI.
 
 ## 4. Buttons on the FTD
 
 Pressing either button 0 or 1 on the FTD will send a UDP message to the FTD containing the string `ftd button`. The MTD must first send a multicast message by pressing the MTD's button 1 so that the FTD knows the address of the MTD to send messages to.
 
-This will toggle the state of LED0 on the MTD. If the MTD is operating as a sleepy end device then the MTD polls the parent every 2 seconds for messages and will update the LED state on the next poll.
-
 ## 5. Monitoring power consumption of the MTD
 
-Open the Energy Profiler within Silicon Labs Simplicity Studio. Within the Quick Access menu select Start Energy Capture... and select the MTD device. When operating as a Sleepy End Device with no LEDs on the current should be under 20 microamps with occasional spikes during waking and polling the parent. With the LED on the MTD has a current consumption of approximately 1mA.
+Open the Energy Profiler within Silicon Labs Simplicity Studio. Within the Quick Access menu select Start Energy Capture... and select the MTD device. When operating as a Sleepy End Device, the current should be under 20 microamps with occasional spikes during waking and polling the parent.
 
 When operating as a Minimal End Device with the Rx on Idle observe that the current is in the order of 10mA.
 

--- a/examples/sleepy-demo/sleepy-demo-ftd/main.c
+++ b/examples/sleepy-demo/sleepy-demo-ftd/main.c
@@ -83,7 +83,6 @@ extern void otAppCliInit(otInstance *aInstance);
 // Variables
 static otInstance *        instance;
 static otUdpSocket         sFtdSocket;
-static bool                sLedOn             = false;
 static bool                sHaveSwitchAddress = false;
 static otIp6Address        sSwitchAddress;
 static bool                sFtdButtonPressed              = false;
@@ -231,10 +230,6 @@ void gpioInit(void (*callback)(uint8_t pin))
     GPIOINT_CallbackRegister(sButtonArray[1].pin, callback);
     GPIO_IntConfig(sButtonArray[0].port, sButtonArray[0].pin, false, true, true);
     GPIO_IntConfig(sButtonArray[1].port, sButtonArray[1].pin, false, true, true);
-
-    BSP_LedsInit();
-    BSP_LedClear(0);
-    BSP_LedClear(1);
 }
 
 void initUdp(void)
@@ -328,16 +323,6 @@ void sFtdReceiveCallback(void *aContext, otMessage *aMessage, const otMessageInf
     sHaveSwitchAddress = true;
     memcpy(&sSwitchAddress, &aMessageInfo->mPeerAddr, sizeof sSwitchAddress);
 
-    // Toggle LED0
-    sLedOn = !sLedOn;
-    if (sLedOn)
-    {
-        BSP_LedSet(0);
-    }
-    else
-    {
-        BSP_LedClear(0);
-    }
     otCliOutputFormat("Message Received: %s\r\n", buf);
 
 exit:

--- a/examples/sleepy-demo/sleepy-demo-mtd/main.c
+++ b/examples/sleepy-demo/sleepy-demo-mtd/main.c
@@ -91,7 +91,6 @@ static otUdpSocket         sMtdSocket;
 static const ButtonArray_t sButtonArray[BSP_BUTTON_COUNT] = BSP_BUTTON_INIT;
 static bool                sButtonPressed                 = false;
 static bool                sRxOnIdleButtonPressed         = false;
-static bool                sLedOn                         = false;
 static bool                sAllowDeepSleep                = false;
 static bool                sTaskletsPendingSem            = true;
 
@@ -278,10 +277,6 @@ void gpioInit(void (*callback)(uint8_t pin))
     GPIOINT_CallbackRegister(sButtonArray[1].pin, callback);
     GPIO_IntConfig(sButtonArray[0].port, sButtonArray[0].pin, false, true, true);
     GPIO_IntConfig(sButtonArray[1].port, sButtonArray[1].pin, false, true, true);
-
-    BSP_LedsInit();
-    BSP_LedClear(0);
-    BSP_LedClear(1);
 }
 
 void initUdp(void)
@@ -399,16 +394,6 @@ void mtdReceiveCallback(void *aContext, otMessage *aMessage, const otMessageInfo
     // Check that the payload matches FTD_MESSAGE
     VerifyOrExit(strncmp((char *)buf, FTD_MESSAGE, sizeof(FTD_MESSAGE)) == 0);
 
-    // Toggle LED0
-    sLedOn = !sLedOn;
-    if (sLedOn)
-    {
-        BSP_LedSet(0);
-    }
-    else
-    {
-        BSP_LedClear(0);
-    }
     otCliOutputFormat("Message Received: %s\r\n", buf);
 
 exit:


### PR DESCRIPTION
This removes LED support from the sleepy-demo example apps

Some boards have limited GPIO and, as a result, button 0 and LED 0 share the same pin. The same is true for button 1 and LED 1 on these boards.

Instead of special-casing, the decision was made to just remove LEDs from the apps.

Users will still be able to see button presses by monitoring the CLI output of both apps﻿
