### PR TITLE
[build] fix platform validity check

### DIFF
--- a/script/build
+++ b/script/build
@@ -125,7 +125,7 @@ main()
     fi
 
     local platform="$1"
-    echo "$efr32_platforms" | grep -wq "${platform}" || die "Unsupported platform ${platform}"
+    efr32_check_platform "${platform}" || die "Unsupported platform ${platform}"
     shift
 
     local options=("${OT_OPTIONS[@]}")


### PR DESCRIPTION
This switches to using `efr32_check_platform` to check if a platform is valid. This should fix the issues with broken pipes that the CI is running into.

Fixes #246
