### PR TITLE
Community discussions change

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,8 @@ Please only use the OpenThread name and marks when accurately referencing this s
 
 # Need help?
 
-There are numerous avenues for OpenThread support:
+OpenThread support is available on GitHub:
 
-- Bugs and feature requests — [submit to the Issue Tracker](https://github.com/openthread/openthread/issues)
-- Stack Overflow — [post questions using the `openthread` tag](http://stackoverflow.com/questions/tagged/openthread)
-- Google Groups — [discussion and announcements at openthread-users](https://groups.google.com/forum/#!forum/openthread-users)
-
-The openthread-users Google Group is the recommended place for users to discuss OpenThread and interact directly with the OpenThread team.
+- Bugs and feature requests pertaining to the OpenThread on EFR32 Examples — [submit to the openthread/ot-efr32 Issue Tracker](https://github.com/openthread/ot-efr32/issues)
+- OpenThread bugs and feature requests — [submit to the OpenThread Issue Tracker](https://github.com/openthread/openthread/issues)
+- Community Discussion - [ask questions, share ideas, and engage with other community members](https://github.com/openthread/openthread/discussions)


### PR DESCRIPTION
Replace link to openthread-users Google Group with link to GitHub OpenThread Discussions, clarify issue reporting links.