### PR TITLE
[github-actions] cache git LFS directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,20 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-        lfs: true
+
+    - name: Create LFS file hash list
+      run: git -C third_party/silabs/gecko_sdk lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+    - name: Restore gecko_sdk LFS cache
+      uses: actions/cache@v2
+      id: lfs-cache
+      with:
+          path: .git/modules/third_party/silabs/gecko_sdk/lfs
+          key: lfs-${{ hashFiles('.lfs-assets-id') }}
+
+    - name: Git LFS Pull
+      run: git -C third_party/silabs/gecko_sdk lfs pull
+
     - uses: actions/setup-java@v3
       with:
         distribution: 'temurin' # See 'Supported distributions' for available options


### PR DESCRIPTION
We've used ~5.3TB of bandwidth in the last month. This is because every GitHub action is pulling the Git LFS objects unconditionally.

The implementation is from: actions/checkout#165
