### PR TITLE
[platform] fix bugs when building platform libs with power manager

### DIFF
--- a/src/src/sleep.h
+++ b/src/src/sleep.h
@@ -36,6 +36,8 @@
 #ifndef SLEEP_H_
 #define SLEEP_H_
 
+#include <stdbool.h>
+
 void sl_ot_sleep_init(void);
 bool sl_ot_is_ok_to_sleep(void);
 

--- a/src/src/system.c
+++ b/src/src/system.c
@@ -54,6 +54,10 @@
 
 #include "sl_system_init.h"
 
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+#include "sl_power_manager.h"
+#endif // SL_CATALOG_POWER_MANAGER_PRESENT
+
 #if defined(SL_CATALOG_KERNEL_PRESENT)
 #include "sl_system_kernel.h"
 #else


### PR DESCRIPTION
Currently if a user generates the platform library using the `power_manager` component, the build will throw a warning in [`otSysProcessDrivers()`](https://github.com/openthread/ot-efr32/blob/41d97122ff121afaaf1c4b2f8274f7d2537ca21a/src/src/system.c#L154-L157) because the header for `sl_power_manager_sleep()` is missing.

This fixes it and also fixes a missing `stdbool.h` include