### PR TITLE
[sleep] only call sl_power_manager_sleep() in baremetal environment

### DIFF
--- a/src/src/system.c
+++ b/src/src/system.c
@@ -155,7 +155,7 @@ void otSysProcessDrivers(otInstance *aInstance)
     // See alarm.c: Wrapped in a critical section
     efr32AlarmProcess(aInstance);
 
-#if defined(SL_CATALOG_POWER_MANAGER_PRESENT)
+#if defined(SL_CATALOG_POWER_MANAGER_PRESENT) && !defined(SL_CATALOG_KERNEL_PRESENT)
     // Let the CPU go to sleep if the system allows it.
     sl_power_manager_sleep();
 #endif


### PR DESCRIPTION
This fixes a freeRTOS assert due to the device going to sleep unexpectedly since freeRTOS is supposed to be managing when the device goes to sleep
