### PR TITLE
[examples] enable `ping` in sleepy-demo apps

### DIFF
--- a/script/build_example_apps
+++ b/script/build_example_apps
@@ -57,6 +57,7 @@ readonly OT_OPTIONS=(
     "-DCMAKE_BUILD_TYPE=Release"
     "-DOT_DIAGNOSTIC=ON"
     "-DOT_EXTERNAL_HEAP=ON"
+    "-DOT_PING_SENDER=ON"
     "-DOT_SLAAC=ON"
 )
 


### PR DESCRIPTION
[A change](https://github.com/openthread/openthread/pull/7979/files#diff-2dfd8d58f7ec7b21e573c09220dc27e20c77fb6fea1afd92e370c90b1a8f4f8aR121) from https://github.com/openthread/openthread/pull/7979 makes it so that `OT_PING_SENDER`'s default value is `OT_APP_CLI` which is a CMake option that's used to enable/disable building of the `ot-cli-ftd`.

This PR explicitly turns on `OT_PING_SENDER` when building the `sleepy-demo` apps
