### PR TITLE
[actions] update `actions/cache` to `v3`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
       run: git -C third_party/silabs/gecko_sdk lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
 
     - name: Restore gecko_sdk LFS cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: lfs-cache
       with:
           path: .git/modules/third_party/silabs/gecko_sdk/lfs


### PR DESCRIPTION
`actions/cache@v2` uses some depracated commands. https://github.com/openthread/ot-efr32/actions/runs/3284516083/jobs/5410564966#step:4:6

This updates to `actions/cache@v3` which should fix the warning