### PR TITLE
[actions] upload build artifacts on failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,3 +96,19 @@ jobs:
       run: |
         export PATH=/tmp/${{ matrix.gcc_extract_dir }}/bin:$PATH
         script/test
+    - name: Gather SLC generated files
+      if: failure()
+      run: |
+        rm -rf artifact && mkdir artifact
+        for b in build/*/slc; do
+            board=$(basename $(dirname "${b}"))
+
+            echo "Artifacting '${board}'"
+            mkdir -p "artifact/${board}"
+            mv "build/${board}/slc" "artifact/${board}"
+        done
+    - uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: build-${{ matrix.gcc_ver }}-${{ matrix.os }}
+        path: artifact

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 .libs
 .vagrant
 aclocal.m4
+artifact/
 autom4te.cache
 build
 CMakeCache.txt


### PR DESCRIPTION
I've been seeing SLC generation failing intermittently both in GitHub Actions ([example](
https://github.com/openthread/ot-efr32/actions/runs/4561484245/jobs/8047495581?pr=547)) and in our internal Jenkins server.

Adding this for more debug data on failures.