### PR TITLE
[docker] test docker image before pushing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,11 +108,16 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Docker Buildx (push)
-      if: success() && github.repository == 'SiliconLabs/ot-efr32' && github.event_name != 'pull_request'
+      if: |
+        success() &&
+        github.repository == 'SiliconLabs/ot-efr32' &&
+        github.event_name != 'pull_request'
+      run: |
+        docker buildx build --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}
+        docker buildx imagetools inspect ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
+
+    - name: Docker Buildx (tag as "latest" and push)
+      if: github.ref == 'refs/heads/main'
       run: |
         docker buildx build --output "type=image,push=true" --tag ${DOCKER_IMAGE}:latest ${{ steps.prepare.outputs.buildx_args }}
-
-    - name: Inspect Image
-      if: always() && github.repository == 'SiliconLabs/ot-efr32' && github.event_name != 'pull_request'
-      run: |
-        docker buildx imagetools inspect ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
+        docker buildx imagetools inspect ${DOCKER_IMAGE}:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,12 @@
 
 name: Docker
 
+env:
+  DOCKER_IMAGE: siliconlabsinc/ot-efr32-dev
+  DOCKER_FILE: Dockerfile
+  DOCKER_PLATFORMS: linux/amd64
+  VERSION: ${{ github.sha }}
+
 on:
   push:
     branches-ignore:
@@ -47,6 +53,7 @@ jobs:
   buildx:
     name: buildx
     runs-on: ubuntu-22.04
+
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@128a63446a954579617e875aaab7d2978154e969 # v2.4.0
@@ -57,23 +64,28 @@ jobs:
       with:
         submodules: true
 
+    - name: Create LFS file hash list
+      run: git -C third_party/silabs/gecko_sdk lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+    - name: Restore gecko_sdk LFS cache
+      uses: actions/cache@v3
+      id: lfs-cache
+      with:
+          path: .git/modules/third_party/silabs/gecko_sdk/lfs
+          key: lfs-${{ hashFiles('.lfs-assets-id') }}
+
+    - name: Git LFS Pull
+      run: git -C third_party/silabs/gecko_sdk lfs pull
+
     - name: Prepare
       id: prepare
       run: |
-        DOCKER_IMAGE=siliconlabsinc/ot-efr32-dev
-        DOCKER_FILE=Dockerfile
-        DOCKER_PLATFORMS=linux/amd64
-        VERSION=latest
-
         TAGS="--tag ${DOCKER_IMAGE}:${VERSION}"
 
         echo "docker_image=${DOCKER_IMAGE}" >> $GITHUB_OUTPUT
         echo "version=${VERSION}" >> $GITHUB_OUTPUT
         echo "buildx_args=--platform ${DOCKER_PLATFORMS} \
-          --build-arg OT_GIT_REF=${{ github.sha }} \
-          --build-arg VERSION=${VERSION} \
           --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
-          --build-arg VCS_REF=${GITHUB_SHA::8} \
           ${TAGS} --file ${DOCKER_FILE} ." >> $GITHUB_OUTPUT
 
     - name: Set up Docker Buildx
@@ -82,6 +94,11 @@ jobs:
     - name: Docker Buildx (build)
       run: |
         docker buildx build --output "type=image,push=false" ${{ steps.prepare.outputs.buildx_args }}
+
+    - name: Test build inside container
+      run: |
+        docker buildx build --load --output "type=docker" ${{ steps.prepare.outputs.buildx_args }}
+        docker run -v ${{ github.workspace }}:/ot-efr32/ --rm ${DOCKER_IMAGE}:${VERSION} script/build brd4186c
 
     - name: Login to DockerHub
       if: success() && github.repository == 'SiliconLabs/ot-efr32' && github.event_name != 'pull_request'
@@ -93,7 +110,7 @@ jobs:
     - name: Docker Buildx (push)
       if: success() && github.repository == 'SiliconLabs/ot-efr32' && github.event_name != 'pull_request'
       run: |
-        docker buildx build --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}
+        docker buildx build --output "type=image,push=true" --tag ${DOCKER_IMAGE}:latest ${{ steps.prepare.outputs.buildx_args }}
 
     - name: Inspect Image
       if: always() && github.repository == 'SiliconLabs/ot-efr32' && github.event_name != 'pull_request'

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,6 @@ ARG REPO_URL="https://github.com/openthread/ot-efr32"
 WORKDIR /
 RUN rm -rf ${repo_dir} && git clone ${REPO_URL} ${repo_dir}
 WORKDIR ${repo_dir}
+
+ARG BUILD_DATE
+LABEL build_date=${BUILD_DATE}

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -50,7 +50,7 @@ install_packages_apt()
     sudo apt-get update
     sudo apt-get --no-install-recommends install -y \
         coreutils \
-        openjdk-11-jre \
+        openjdk-17-jre \
         python3-setuptools \
         python3-pip \
         git-lfs \

--- a/script/generate_cmake.py
+++ b/script/generate_cmake.py
@@ -30,11 +30,12 @@
 
 from itertools import filterfalse
 from jinja2 import Environment, FileSystemLoader
+from pathlib import Path
 import copy
 import git
 import yaml
 import argparse
-import pathlib
+import os
 
 
 def prepare_path(path: str) -> str:
@@ -137,15 +138,15 @@ parser.add_argument(
     "output_dir", help="the output dir for any generated files")
 args = parser.parse_args()
 
-git_repo = git.Repo(__file__, search_parent_directories=True)
-git_root = git_repo.git.rev_parse("--show-toplevel")
+script_dir = Path(os.path.dirname(os.path.abspath(__file__)))
+repo_root = script_dir.parent
 
 # Define CMakeLists.txt template location
 environment = Environment(loader=FileSystemLoader(
-    f"{git_root}/slc/exporter_templates/platform_library"))
+    f"{repo_root}/slc/exporter_templates/platform_library"))
 platform_lib_template = environment.get_template("CMakeLists.txt.jinja")
 mbedtls_lib_template = environment.get_template("mbedtls.cmake.jinja")
-slc_vars_yaml_dir = pathlib.Path(args.slc_vars_yaml).parent
+slc_vars_yaml_dir = Path(args.slc_vars_yaml).parent
 platform_lib_output_file = slc_vars_yaml_dir / "CMakeLists.txt"
 mbedtls_lib_output_file = slc_vars_yaml_dir / "mbedtls.cmake"
 


### PR DESCRIPTION
This adds a step in the docker workflow that runs `script/test` inside a container created using the newly built `siliconlabsinc/ot-efr32-dev` image before pushing the image to Docker Hub.

Other Changes:
- [actions] use cache for lfs pull in docker workflow
  - (related to openthread/ot-efr32#336)
- [script] update [`script/bootstrap`](https://github.com/openthread/ot-efr32/pull/619/files#diff-2ad9e188678c4f3bef503efff261066b6c9df3a948bcaabe8bc10bdd2f45404a) java version due to SLC requiring Java 17
- [script] update [`script/generate_cmake.py`](https://github.com/openthread/ot-efr32/pull/619/files#diff-64f5739113084f2c5ddf82cab14384806594d7c83f6f371463200631dfff9796) to work when repo sources are not in a git environment (ie when downloaded as a .zip)
  - (related to openthread/ot-efr32#566)
