### PR TITLE
[crypto] implement PBKDF2 key generation using PSA

### DIFF
--- a/ot-efr32.slce
+++ b/ot-efr32.slce
@@ -4,6 +4,6 @@ description: "ot-efr32 extension for Gecko SDK Suite"
 label: "Silicon Labs Matter"
 sdk:
   id: gecko_sdk
-  version: 4.2.1
+  version: 4.3.2
 component_path:
   - path: slc/component

--- a/slc/component/ot_psa_crypto.slcc
+++ b/slc/component/ot_psa_crypto.slcc
@@ -1,0 +1,30 @@
+id: ot_psa_crypto
+label: PSA Crypto
+package: OpenThread
+category: OpenThread
+quality: production
+description: This component references to all the third party support needed by the OpenThread stack
+ui_hints:
+  visibility: never
+provides:
+  - name: ot_psa_crypto
+requires:
+  - name: psa_crypto
+  - name: psa_its
+  - name: psa_crypto_hkdf
+  - name: psa_crypto_cmac
+  - name: psa_crypto_hmac
+  - name: psa_crypto_tls12_prf
+  - name: psa_crypto_tls12_psk_to_ms
+  - name: psa_crypto_sha256
+  - name: psa_crypto_ecdh
+  - name: psa_crypto_ecdsa
+  - name: psa_crypto_ecc_secp256r1
+  - name: psa_crypto_pbkdf2_cmac
+template_contribution:
+  - name: mbedtls_config
+    value: MBEDTLS_USE_PSA_CRYPTO
+  - name: psa_key_slots
+    value:
+      name: psa_key_slots_openthread
+      count: 15

--- a/src/platform_projects/openthread-efr32-soc-with-buttons-power-manager-csl.slcp
+++ b/src/platform_projects/openthread-efr32-soc-with-buttons-power-manager-csl.slcp
@@ -9,6 +9,7 @@ quality: production
 component:
   - id: ot_platform_abstraction_core
   - id: ot_psa_crypto
+    from: ot-efr32
   - id: ot_thirdparty
   - id: uartdrv_usart
     instance:
@@ -53,3 +54,10 @@ configuration:
 define:
   - name: OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     value: 1
+
+sdk:
+  id: gecko_sdk
+  version: 4.3.2
+sdk_extension:
+  - id: ot-efr32
+    version: 0.0.1

--- a/src/platform_projects/openthread-efr32-soc-with-buttons-power-manager.slcp
+++ b/src/platform_projects/openthread-efr32-soc-with-buttons-power-manager.slcp
@@ -9,6 +9,7 @@ quality: production
 component:
   - id: ot_platform_abstraction_core
   - id: ot_psa_crypto
+    from: ot-efr32
   - id: ot_thirdparty
   - id: uartdrv_usart
     instance:
@@ -49,3 +50,10 @@ configuration:
     condition: [freertos]
   - name: SL_STACK_SIZE
     value: 4608
+
+sdk:
+  id: gecko_sdk
+  version: 4.3.2
+sdk_extension:
+  - id: ot-efr32
+    version: 0.0.1

--- a/src/platform_projects/openthread-efr32-soc-with-buttons.slcp
+++ b/src/platform_projects/openthread-efr32-soc-with-buttons.slcp
@@ -9,6 +9,7 @@ quality: production
 component:
   - id: ot_platform_abstraction_core
   - id: ot_psa_crypto
+    from: ot-efr32
   - id: ot_thirdparty
   - id: uartdrv_usart
     instance:
@@ -48,3 +49,10 @@ configuration:
     condition: [freertos]
   - name: SL_STACK_SIZE
     value: 4608
+
+sdk:
+  id: gecko_sdk
+  version: 4.3.2
+sdk_extension:
+  - id: ot-efr32
+    version: 0.0.1

--- a/src/platform_projects/openthread-efr32-soc.slcp
+++ b/src/platform_projects/openthread-efr32-soc.slcp
@@ -8,6 +8,7 @@ quality: production
 component:
   - id: ot_platform_abstraction_core
   - id: ot_psa_crypto
+    from: ot-efr32
   - id: ot_thirdparty
   - id: uartdrv_usart
     instance:
@@ -35,3 +36,10 @@ configuration:
     condition: [freertos]
   - name: SL_STACK_SIZE
     value: 4608
+
+sdk:
+  id: gecko_sdk
+  version: 4.3.2
+sdk_extension:
+  - id: ot-efr32
+    version: 0.0.1


### PR DESCRIPTION
This commit adds support for PBKDF2 operation using PSA crypto. We import the salt and password into PSA and generate the key. The generated key is then exported into a flat buffer and all the transient keys are destroyed.

Remove dependency on psa_crypto_pbkdf2 component, psa_crypto_pbkdf2_cmac should be enough for our usecase