### PR TITLE
[sdk] update to GSDK 4.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,18 +50,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - gcc_ver: 6
-            gcc_download_url: https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2
-            gcc_extract_dir: gcc-arm-none-eabi-6-2017-q2-update
-          - gcc_ver: 7
-            gcc_download_url: https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2
-            gcc_extract_dir: gcc-arm-none-eabi-7-2018-q2-update
-          - gcc_ver: 9
-            gcc_download_url: https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/RC2.1/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2
-            gcc_extract_dir: gcc-arm-none-eabi-9-2019-q4-major
-          - gcc_ver: 10.3
-            gcc_download_url: https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2
-            gcc_extract_dir: gcc-arm-none-eabi-10.3-2021.10
+          - gcc_ver: 12.2.Rel1
+            gcc_download_url: https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi.tar.xz
+            gcc_extract_dir: arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi
+          - gcc_ver: 12.3.Rel1
+            gcc_download_url: https://developer.arm.com/-/media/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi.tar.xz
+            gcc_extract_dir: arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi
 
     steps:
     - uses: actions/checkout@v4
@@ -83,13 +77,12 @@ jobs:
 
     - name: Bootstrap
       run: |
-        cd /tmp
-        wget --tries 4 --no-check-certificate --quiet ${{ matrix.gcc_download_url }} -O gcc-arm.tar.bz2
-        tar xjf gcc-arm.tar.bz2
+        script/bootstrap packages
+        script/bootstrap arm_toolchain ${{ matrix.gcc_download_url }} ${{ matrix.gcc_extract_dir }}
 
     - name: Build
       run: |
-        export PATH=/tmp/${{ matrix.gcc_extract_dir }}/bin:$PATH
+        export PATH=${HOME}/.local/${{ matrix.gcc_extract_dir }}/bin:$PATH
         script/test
 
     - name: Gather SLC generated files
@@ -107,5 +100,5 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: build-${{ matrix.gcc_ver }}-${{ matrix.os }}
+        name: build-${{ matrix.gcc_ver }}
         path: artifact

--- a/examples/example_vendor_slc_extension/projects/example-vendor-rcp-spi.slcp
+++ b/examples/example_vendor_slc_extension/projects/example-vendor-rcp-spi.slcp
@@ -36,6 +36,8 @@ quality: production
 component:
   - id: ot_platform_abstraction_core
   - id: ot_mbedtls
+  - id: ot_stack_features_config
+    from: ot-efr32
   - id: ot_ncp_spidrv
   - id: rail_util_pti
 

--- a/examples/example_vendor_slc_extension/projects/example-vendor-rcp-spi.slcp
+++ b/examples/example_vendor_slc_extension/projects/example-vendor-rcp-spi.slcp
@@ -35,7 +35,7 @@ quality: production
 
 component:
   - id: ot_platform_abstraction_core
-  - id: ot_thirdparty
+  - id: ot_mbedtls
   - id: ot_ncp_spidrv
   - id: rail_util_pti
 

--- a/examples/example_vendor_slc_extension/projects/example-vendor-rcp-uart.slcp
+++ b/examples/example_vendor_slc_extension/projects/example-vendor-rcp-uart.slcp
@@ -35,7 +35,7 @@ quality: production
 
 component:
   - id: ot_platform_abstraction_core
-  - id: ot_thirdparty
+  - id: ot_mbedtls
   - id: uartdrv_usart
     instance:
       - vcom

--- a/examples/example_vendor_slc_extension/projects/example-vendor-rcp-uart.slcp
+++ b/examples/example_vendor_slc_extension/projects/example-vendor-rcp-uart.slcp
@@ -36,6 +36,8 @@ quality: production
 component:
   - id: ot_platform_abstraction_core
   - id: ot_mbedtls
+  - id: ot_stack_features_config
+    from: ot-efr32
   - id: uartdrv_usart
     instance:
       - vcom

--- a/examples/example_vendor_slc_extension/projects/example-vendor-soc-with-buttons.slcp
+++ b/examples/example_vendor_slc_extension/projects/example-vendor-soc-with-buttons.slcp
@@ -36,7 +36,7 @@ quality: production
 component:
   - id: ot_platform_abstraction_core
   - id: ot_psa_crypto
-  - id: ot_thirdparty
+  - id: ot_mbedtls
   - id: uartdrv_usart
     instance:
       - vcom

--- a/examples/example_vendor_slc_extension/projects/example-vendor-soc-with-buttons.slcp
+++ b/examples/example_vendor_slc_extension/projects/example-vendor-soc-with-buttons.slcp
@@ -37,6 +37,8 @@ component:
   - id: ot_platform_abstraction_core
   - id: ot_psa_crypto
   - id: ot_mbedtls
+  - id: ot_stack_features_config
+    from: ot-efr32
   - id: uartdrv_usart
     instance:
       - vcom

--- a/examples/example_vendor_slc_extension/projects/example-vendor-soc.slcp
+++ b/examples/example_vendor_slc_extension/projects/example-vendor-soc.slcp
@@ -36,7 +36,7 @@ quality: production
 component:
   - id: ot_platform_abstraction_core
   - id: ot_psa_crypto
-  - id: ot_thirdparty
+  - id: ot_mbedtls
   - id: uartdrv_usart
     instance:
       - vcom

--- a/examples/example_vendor_slc_extension/projects/example-vendor-soc.slcp
+++ b/examples/example_vendor_slc_extension/projects/example-vendor-soc.slcp
@@ -37,6 +37,8 @@ component:
   - id: ot_platform_abstraction_core
   - id: ot_psa_crypto
   - id: ot_mbedtls
+  - id: ot_stack_features_config
+    from: ot-efr32
   - id: uartdrv_usart
     instance:
       - vcom

--- a/ot-efr32.slce
+++ b/ot-efr32.slce
@@ -1,9 +1,9 @@
 id: ot-efr32
 version: 0.0.1
 description: "ot-efr32 extension for Gecko SDK Suite"
-label: "Silicon Labs Matter"
+label: "Silicon Labs OpenThread"
 sdk:
   id: gecko_sdk
-  version: 4.2.1
+  version: 4.4.0
 component_path:
   - path: slc/component

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -55,7 +55,8 @@ install_packages_apt()
         python3-pip \
         git-lfs \
         unzip \
-        wget
+        wget \
+        xz-utils
 }
 
 install_packages_opkg()
@@ -118,6 +119,38 @@ do_bootstrap_silabs()
     echo "Bootstrapping silabs"
     "${repo_dir}"/script/bootstrap_silabs
 }
+
+install_arm_toolchain()
+{
+    local url=${1-"https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi.tar.xz"}
+    local extract_dir=${2-"arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi"}
+
+    local toolchain_dir="${HOME}/.local"
+
+    # Check if the toolchain is already present at the desired location
+    if command -v "${toolchain_dir}/${extract_dir}/bin/arm-none-eabi-gcc"; then
+        echo "'arm-none-eabi-gcc' found. Skipping GNU ARM Embedded toolchain install"
+        "${toolchain_dir}"/"${extract_dir}"/bin/arm-none-eabi-gcc --version
+        return
+    fi
+
+    echo 'Installing GNU ARM Embedded Toolchain...'
+
+    # Download
+    local tarball=gcc-arm.tar.xz
+    mkdir -p "${toolchain_dir}/${extract_dir}"
+    wget --tries 4 --no-check-certificate --quiet "${url}" -O "${toolchain_dir}/${tarball}"
+
+    # Extract
+    tar xf "${toolchain_dir}/${tarball}" --directory "${toolchain_dir}/${extract_dir}" --strip-components=1
+
+    # Link
+    sudo ln -s -f "${toolchain_dir}"/"${extract_dir}"/bin/* /usr/local/bin/
+
+    # Cleanup
+    rm -rf "${toolchain_dir:?}/${tarball:?}"
+}
+
 main()
 {
     if [ $# == 0 ]; then
@@ -126,6 +159,9 @@ main()
         do_bootstrap_silabs
     elif [ "$1" == 'packages' ]; then
         install_packages
+    elif [ "$1" == 'arm_toolchain' ]; then
+        shift 1
+        install_arm_toolchain "$@"
     elif [ "$1" == 'openthread' ]; then
         do_bootstrap_openthread
     elif [ "$1" == 'python' ]; then

--- a/slc/component/ot_stack_features_config.slcc
+++ b/slc/component/ot_stack_features_config.slcc
@@ -1,0 +1,24 @@
+id: ot_stack_features_config
+label: Stack Features Config
+package: OpenThread
+category: OpenThread
+quality: production
+description: This component provides the OpenThread stack features configuration
+provides:
+  - name: ot_stack_features_config
+config_file:
+  - path: third_party/silabs/gecko_sdk/protocol/openthread/config/sl_openthread_features_config.h
+    file_id: openthread_features
+    unless: [ot_reference_device]
+  - path: third_party/silabs/gecko_sdk/protocol/openthread/config/sl_openthread_reference_device_config.h
+    file_id: openthread_features
+    condition: [ot_reference_device]
+validation_helper:
+  - path: third_party/silabs/gecko_sdk/protocol/openthread/component/script/ot_log_validation.lua
+define:
+  - name: SL_OPENTHREAD_STACK_FEATURES_CONFIG_FILE
+    value: "\"sl_openthread_features_config.h\""
+    unless: [ot_reference_device]
+  - name: SL_OPENTHREAD_STACK_FEATURES_CONFIG_FILE
+    value: "\"sl_openthread_reference_device_config.h\""
+    condition: [ot_reference_device]

--- a/src/platform_projects/openthread-efr32-rcp-spi.slcp
+++ b/src/platform_projects/openthread-efr32-rcp-spi.slcp
@@ -8,6 +8,8 @@ quality: production
 component:
   - id: ot_platform_abstraction_core
   - id: ot_mbedtls
+  - id: ot_stack_features_config
+    from: ot-efr32
   - id: ot_ncp_spidrv
   - id: rail_util_pti
 
@@ -20,3 +22,7 @@ define:
     value: 1
   - name: OPENTHREAD_RADIO
     value: 1
+
+sdk_extension:
+- id: ot-efr32
+  version: 0.0.1

--- a/src/platform_projects/openthread-efr32-rcp-spi.slcp
+++ b/src/platform_projects/openthread-efr32-rcp-spi.slcp
@@ -7,7 +7,7 @@ quality: production
 
 component:
   - id: ot_platform_abstraction_core
-  - id: ot_thirdparty
+  - id: ot_mbedtls
   - id: ot_ncp_spidrv
   - id: rail_util_pti
 

--- a/src/platform_projects/openthread-efr32-rcp-uart.slcp
+++ b/src/platform_projects/openthread-efr32-rcp-uart.slcp
@@ -8,6 +8,8 @@ quality: production
 component:
   - id: ot_platform_abstraction_core
   - id: ot_mbedtls
+  - id: ot_stack_features_config
+    from: ot-efr32
   - id: uartdrv_usart
     instance:
       - vcom
@@ -22,3 +24,7 @@ define:
     value: 1
   - name: OPENTHREAD_RADIO
     value: 1
+
+sdk_extension:
+  - id: ot-efr32
+    version: 0.0.1

--- a/src/platform_projects/openthread-efr32-rcp-uart.slcp
+++ b/src/platform_projects/openthread-efr32-rcp-uart.slcp
@@ -7,7 +7,7 @@ quality: production
 
 component:
   - id: ot_platform_abstraction_core
-  - id: ot_thirdparty
+  - id: ot_mbedtls
   - id: uartdrv_usart
     instance:
       - vcom

--- a/src/platform_projects/openthread-efr32-soc-with-buttons-power-manager-csl.slcp
+++ b/src/platform_projects/openthread-efr32-soc-with-buttons-power-manager-csl.slcp
@@ -10,6 +10,8 @@ component:
   - id: ot_platform_abstraction_core
   - id: ot_psa_crypto
   - id: ot_mbedtls
+  - id: ot_stack_features_config
+    from: ot-efr32
   - id: uartdrv_usart
     instance:
       - vcom
@@ -53,3 +55,7 @@ configuration:
 define:
   - name: OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     value: 1
+
+sdk_extension:
+  - id: ot-efr32
+    version: 0.0.1

--- a/src/platform_projects/openthread-efr32-soc-with-buttons-power-manager-csl.slcp
+++ b/src/platform_projects/openthread-efr32-soc-with-buttons-power-manager-csl.slcp
@@ -9,7 +9,7 @@ quality: production
 component:
   - id: ot_platform_abstraction_core
   - id: ot_psa_crypto
-  - id: ot_thirdparty
+  - id: ot_mbedtls
   - id: uartdrv_usart
     instance:
       - vcom

--- a/src/platform_projects/openthread-efr32-soc-with-buttons-power-manager.slcp
+++ b/src/platform_projects/openthread-efr32-soc-with-buttons-power-manager.slcp
@@ -9,7 +9,7 @@ quality: production
 component:
   - id: ot_platform_abstraction_core
   - id: ot_psa_crypto
-  - id: ot_thirdparty
+  - id: ot_mbedtls
   - id: uartdrv_usart
     instance:
       - vcom

--- a/src/platform_projects/openthread-efr32-soc-with-buttons-power-manager.slcp
+++ b/src/platform_projects/openthread-efr32-soc-with-buttons-power-manager.slcp
@@ -10,6 +10,8 @@ component:
   - id: ot_platform_abstraction_core
   - id: ot_psa_crypto
   - id: ot_mbedtls
+  - id: ot_stack_features_config
+    from: ot-efr32
   - id: uartdrv_usart
     instance:
       - vcom
@@ -49,3 +51,7 @@ configuration:
     condition: [freertos]
   - name: SL_STACK_SIZE
     value: 4608
+
+sdk_extension:
+  - id: ot-efr32
+    version: 0.0.1

--- a/src/platform_projects/openthread-efr32-soc-with-buttons.slcp
+++ b/src/platform_projects/openthread-efr32-soc-with-buttons.slcp
@@ -9,7 +9,7 @@ quality: production
 component:
   - id: ot_platform_abstraction_core
   - id: ot_psa_crypto
-  - id: ot_thirdparty
+  - id: ot_mbedtls
   - id: uartdrv_usart
     instance:
       - vcom

--- a/src/platform_projects/openthread-efr32-soc-with-buttons.slcp
+++ b/src/platform_projects/openthread-efr32-soc-with-buttons.slcp
@@ -10,6 +10,8 @@ component:
   - id: ot_platform_abstraction_core
   - id: ot_psa_crypto
   - id: ot_mbedtls
+  - id: ot_stack_features_config
+    from: ot-efr32
   - id: uartdrv_usart
     instance:
       - vcom
@@ -48,3 +50,7 @@ configuration:
     condition: [freertos]
   - name: SL_STACK_SIZE
     value: 4608
+
+sdk_extension:
+  - id: ot-efr32
+    version: 0.0.1

--- a/src/platform_projects/openthread-efr32-soc.slcp
+++ b/src/platform_projects/openthread-efr32-soc.slcp
@@ -8,7 +8,7 @@ quality: production
 component:
   - id: ot_platform_abstraction_core
   - id: ot_psa_crypto
-  - id: ot_thirdparty
+  - id: ot_mbedtls
   - id: uartdrv_usart
     instance:
       - vcom

--- a/src/platform_projects/openthread-efr32-soc.slcp
+++ b/src/platform_projects/openthread-efr32-soc.slcp
@@ -9,6 +9,8 @@ component:
   - id: ot_platform_abstraction_core
   - id: ot_psa_crypto
   - id: ot_mbedtls
+  - id: ot_stack_features_config
+    from: ot-efr32
   - id: uartdrv_usart
     instance:
       - vcom
@@ -35,3 +37,7 @@ configuration:
     condition: [freertos]
   - name: SL_STACK_SIZE
     value: 4608
+
+sdk_extension:
+  - id: ot-efr32
+    version: 0.0.1

--- a/src/src/alarm.c
+++ b/src/src/alarm.c
@@ -32,6 +32,7 @@
  *
  */
 
+#include <assert.h>
 #include <openthread-core-config.h>
 #include <openthread-system.h>
 #include <stdbool.h>

--- a/src/src/crypto.c
+++ b/src/src/crypto.c
@@ -35,14 +35,21 @@
 #include <openthread-core-config.h>
 #include <openthread/error.h>
 #include <openthread/platform/crypto.h>
+#include "common/debug.hpp"
 #include "utils/code_utils.h"
 
+#include "em_device.h"
+#include "em_system.h"
+#include "sl_psa_crypto.h"
 #include <mbedtls/ecdsa.h>
 #include <mbedtls/md.h>
 #include <mbedtls/pk.h>
 #include "mbedtls/psa_util.h"
 
 #if OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_PSA
+
+#define PERSISTENCE_KEY_ID_USED_MAX (7)
+#define MAX_HMAC_KEY_SIZE (32)
 
 // Helper function to convert otCryptoKeyType to psa_key_type_t
 static psa_key_type_t getPsaKeyType(otCryptoKeyType aKeyType)
@@ -134,20 +141,62 @@ static psa_key_persistence_t getPsaKeyPersistence(otCryptoKeyStorage aKeyPersist
     switch (aKeyPersistence)
     {
     case OT_CRYPTO_KEY_STORAGE_VOLATILE:
-        aPsaKeyPersistence = PSA_KEY_LIFETIME_VOLATILE;
+        aPsaKeyPersistence = PSA_KEY_PERSISTENCE_VOLATILE;
         break;
 
     case OT_CRYPTO_KEY_STORAGE_PERSISTENT:
-        aPsaKeyPersistence = PSA_KEY_LIFETIME_PERSISTENT;
+        aPsaKeyPersistence = PSA_KEY_PERSISTENCE_DEFAULT;
         break;
     }
 
     return aPsaKeyPersistence;
 }
 
+#if defined(SEMAILBOX_PRESENT) && !defined(SL_TRUSTZONE_NONSECURE)
+static bool shouldWrap(psa_key_attributes_t *key_attr)
+{
+    psa_key_location_t keyLocation = PSA_KEY_LIFETIME_GET_LOCATION(psa_get_key_lifetime(key_attr));
+    psa_key_type_t     keyType     = psa_get_key_type(key_attr);
+
+    return ((keyLocation != SL_PSA_KEY_LOCATION_WRAPPED) && (keyType != PSA_KEY_TYPE_HMAC));
+}
+
+static void checkAndWrapKeys(void)
+{
+    for (int index = 1; index <= PERSISTENCE_KEY_ID_USED_MAX; index++)
+    {
+        otCryptoKeyRef       key_ref  = OPENTHREAD_CONFIG_PSA_ITS_NVM_OFFSET + index;
+        psa_key_attributes_t key_attr = PSA_KEY_ATTRIBUTES_INIT;
+
+        // If there is a key present in the location..
+        if (sl_sec_man_get_key_attributes(key_ref, &key_attr) == PSA_SUCCESS)
+        {
+            if (shouldWrap(&key_attr))
+            {
+                // Wrap the key..
+                otCryptoKeyRef     dst_key_ref = key_ref;
+                psa_key_lifetime_t key_lifetime =
+                    PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(PSA_KEY_PERSISTENCE_DEFAULT,
+                                                                   SL_PSA_KEY_LOCATION_WRAPPED);
+
+                psa_set_key_lifetime(&key_attr, key_lifetime);
+                sl_sec_man_copy_key(key_ref, &key_attr, &dst_key_ref);
+            }
+        }
+    }
+}
+#endif // SEMAILBOX_PRESENT && !SL_TRUSTZONE_NONSECURE
+
 void otPlatCryptoInit(void)
 {
     (void)sl_sec_man_init();
+
+#if defined(SEMAILBOX_PRESENT) && !defined(SL_TRUSTZONE_NONSECURE)
+    if (SYSTEM_GetSecurityCapability() == securityCapabilityVault)
+    {
+        checkAndWrapKeys();
+    }
+#endif
 }
 
 static otError extractPrivateKeyFromDer(uint8_t *aPrivateKey, const uint8_t *aDer, uint8_t aDerLen)
@@ -312,15 +361,60 @@ exit:
     return error;
 }
 
+static psa_status_t reImportUnwrapped(const otCryptoKey *aKey, otCryptoKeyRef *aHmacKeyRef)
+{
+    psa_status_t status = PSA_SUCCESS;
+
+#if defined(SEMAILBOX_PRESENT)
+    uint8_t              hmacKeyBytes[MAX_HMAC_KEY_SIZE];
+    size_t               key_size;
+    psa_key_attributes_t key_attr = PSA_KEY_ATTRIBUTES_INIT;
+
+    status = sl_sec_man_get_key_attributes(aKey->mKeyRef, &key_attr);
+
+    otEXPECT(status == PSA_SUCCESS);
+
+    status = sl_sec_man_export_key(aKey->mKeyRef, hmacKeyBytes, sizeof(hmacKeyBytes), &key_size);
+
+    otEXPECT(status == PSA_SUCCESS);
+
+    status = sl_sec_man_import_key(aHmacKeyRef,
+                                   psa_get_key_type(&key_attr),
+                                   psa_get_key_algorithm(&key_attr),
+                                   psa_get_key_usage_flags(&key_attr),
+                                   PSA_KEY_PERSISTENCE_VOLATILE,
+                                   hmacKeyBytes,
+                                   key_size);
+
+    memset(hmacKeyBytes, 0, sizeof(hmacKeyBytes));
+
+    otEXPECT(status == PSA_SUCCESS);
+
+exit:
+#else
+    *aHmacKeyRef = aKey->mKeyRef;
+#endif
+    return status;
+}
+
 otError otPlatCryptoHmacSha256Start(otCryptoContext *aContext, const otCryptoKey *aKey)
 {
     otError              error         = OT_ERROR_NONE;
     psa_mac_operation_t *mMacOperation = (psa_mac_operation_t *)aContext->mContext;
     psa_status_t         status;
+    otCryptoKeyRef       hmacKeyRef;
 
-    status = sl_sec_man_hmac_start(mMacOperation, aKey->mKeyRef);
-
+    status = reImportUnwrapped(aKey, &hmacKeyRef);
     otEXPECT_ACTION((status == PSA_SUCCESS), error = OT_ERROR_FAILED);
+
+    status = sl_sec_man_hmac_start(mMacOperation, hmacKeyRef);
+    otEXPECT_ACTION((status == PSA_SUCCESS), error = OT_ERROR_FAILED);
+
+#if defined(SEMAILBOX_PRESENT)
+    sl_sec_man_destroy_key(hmacKeyRef);
+#else
+    hmacKeyRef   = 0;
+#endif
 
 exit:
     return error;
@@ -553,6 +647,83 @@ otError otPlatCryptoEcdsaVerifyUsingKeyRef(otCryptoKeyRef                    aKe
 
 exit:
     return error;
+}
+
+void otPlatCryptoPbkdf2GenerateKey(const uint8_t *aPassword,
+                                   uint16_t       aPasswordLen,
+                                   const uint8_t *aSalt,
+                                   uint16_t       aSaltLen,
+                                   uint32_t       aIterationCounter,
+                                   uint16_t       aKeyLen,
+                                   uint8_t       *aKey)
+{
+    psa_status_t status;
+    size_t       outSize;
+    psa_key_id_t passwordKeyId = 0;
+    psa_key_id_t saltKeyId     = 0;
+    psa_key_id_t keyId         = 0;
+
+    // Algorithm is PBKDF2-AES-CMAC-PRF-128
+    psa_algorithm_t algo = PSA_ALG_PBKDF2_AES_CMAC_PRF_128;
+
+    // Initialize key derivation
+    psa_key_derivation_operation_t operation = psa_key_derivation_operation_init();
+    status                                   = psa_key_derivation_setup(&operation, algo);
+    OT_ASSERT(status == PSA_SUCCESS);
+
+    // Set capacity
+    status = psa_key_derivation_set_capacity(&operation, aKeyLen);
+    OT_ASSERT(status == PSA_SUCCESS);
+
+    // Set iteration count as cost
+    status = psa_key_derivation_input_integer(&operation, PSA_KEY_DERIVATION_INPUT_COST, aIterationCounter);
+    OT_ASSERT(status == PSA_SUCCESS);
+
+    // Create salt as a key
+    psa_key_attributes_t saltKeyAttr = psa_key_attributes_init();
+    psa_set_key_usage_flags(&saltKeyAttr, PSA_KEY_USAGE_DERIVE);
+    psa_set_key_type(&saltKeyAttr, PSA_KEY_TYPE_RAW_DATA);
+    psa_set_key_algorithm(&saltKeyAttr, algo);
+    OT_ASSERT(status == PSA_SUCCESS);
+
+    status = psa_import_key(&saltKeyAttr, aSalt, aSaltLen, &saltKeyId);
+    OT_ASSERT(status == PSA_SUCCESS);
+
+    // Provide salt
+    status = psa_key_derivation_input_key(&operation, PSA_KEY_DERIVATION_INPUT_SALT, saltKeyId);
+    OT_ASSERT(status == PSA_SUCCESS);
+
+    // Create key for password (key)
+    psa_key_attributes_t passwordKeyAttr = psa_key_attributes_init();
+    psa_set_key_usage_flags(&passwordKeyAttr, PSA_KEY_USAGE_DERIVE);
+    psa_set_key_type(&passwordKeyAttr, PSA_KEY_TYPE_PASSWORD);
+    psa_set_key_algorithm(&passwordKeyAttr, algo);
+
+    status = psa_import_key(&passwordKeyAttr, aPassword, aPasswordLen, &passwordKeyId);
+    OT_ASSERT(status == PSA_SUCCESS);
+
+    // Provide password (key)
+    status = psa_key_derivation_input_key(&operation, PSA_KEY_DERIVATION_INPUT_PASSWORD, passwordKeyId);
+    OT_ASSERT(status == PSA_SUCCESS);
+
+    // Configure output as a key
+    psa_key_attributes_t keyAttrResult = psa_key_attributes_init();
+    psa_set_key_bits(&keyAttrResult, (8 * aKeyLen));
+    psa_set_key_usage_flags(&keyAttrResult, PSA_KEY_USAGE_EXPORT);
+    psa_set_key_type(&keyAttrResult, PSA_KEY_TYPE_RAW_DATA);
+    psa_set_key_algorithm(&keyAttrResult, PSA_ALG_CTR);
+
+    status = psa_key_derivation_output_key(&keyAttrResult, &operation, &keyId);
+    OT_ASSERT(status == PSA_SUCCESS);
+
+    // Export output key
+    status = psa_export_key(keyId, aKey, aKeyLen, &outSize);
+    OT_ASSERT(status == PSA_SUCCESS);
+
+    // Release keys used
+    psa_destroy_key(keyId);
+    psa_destroy_key(saltKeyId);
+    psa_destroy_key(passwordKeyId);
 }
 
 #endif // OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE

--- a/src/src/diag.c
+++ b/src/src/diag.c
@@ -32,6 +32,7 @@
  *
  */
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <sys/time.h>

--- a/src/src/ieee802154-packet-utils.cpp
+++ b/src/src/ieee802154-packet-utils.cpp
@@ -39,6 +39,7 @@
 #include "sl_packet_utils.h"
 #include "sli_protocol_crypto.h"
 
+#include <assert.h>
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "crypto/aes_ccm.hpp"

--- a/src/src/logging_rtt.c
+++ b/src/src/logging_rtt.c
@@ -27,8 +27,8 @@
  */
 
 /**
- * @file logging.c
- * Platform abstraction for the logging
+ * @file logging_rtt.c
+ *  This file implements the OpenThread platform abstraction for logging using RTT interface.
  *
  */
 

--- a/src/src/openthread-core-efr32-config.h
+++ b/src/src/openthread-core-efr32-config.h
@@ -58,6 +58,16 @@
 #include "em_device.h"
 
 /**
+ * @def OPENTHREAD_CONFIG_PLATFORM_BOOTLOADER_MODE_ENABLE
+ *
+ * Allow triggering a platform reset to bootloader mode, if supported.
+ *
+ */
+#if defined(SL_CATALOG_GECKO_BOOTLOADER_INTERFACE_PRESENT)
+#define OPENTHREAD_CONFIG_PLATFORM_BOOTLOADER_MODE_ENABLE 1
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_PLATFORM_MAC_KEYS_EXPORTABLE_ENABLE
  *
  * Calling crypto functions in interrupt context when another operation is running
@@ -180,6 +190,24 @@
  */
 #ifndef OPENTHREAD_CONFIG_UPTIME_ENABLE
 #define OPENTHREAD_CONFIG_UPTIME_ENABLE OPENTHREAD_FTD
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT
+ *
+ * The default supervision check timeout interval (in seconds) used by a device in child state. Set to zero to disable
+ * the supervision check process on the child.
+ *
+ * The check timeout interval can be changed using `otChildSupervisionSetCheckTimeout()`.
+ *
+ * If the sleepy child does not hear from its parent within the specified timeout interval, it initiates the re-attach
+ * process (MLE Child Update Request/Response exchange with its parent).
+ *
+ * Setting to zero by default as this is an optional feature that can lead to unexpected detach behavior.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT
+#define OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT 0
 #endif
 
 /**

--- a/src/src/platform-band.h
+++ b/src/src/platform-band.h
@@ -53,7 +53,6 @@
 #define RADIO_TIMING_CSMA_OVERHEAD_US 500
 #define RADIO_TIMING_DEFAULT_BYTETIME_US 32   // only used if RAIL_GetBitRate returns 0
 #define RADIO_TIMING_DEFAULT_SYMBOLTIME_US 16 // only used if RAIL_GetSymbolRate returns 0
-
 typedef struct efr32CommonConfig
 {
     RAIL_Config_t mRailConfig;

--- a/src/src/platform-efr32.h
+++ b/src/src/platform-efr32.h
@@ -154,6 +154,12 @@ void efr32LogInit(void);
 void efr32LogDeinit(void);
 
 /**
+ * Print reset info.
+ *
+ */
+void efr32PrintResetInfo(void);
+
+/**
  * Set 802.15.4 CCA mode
  *
  * A call to this function should be made after RAIL has been

--- a/src/src/rail_config.h
+++ b/src/src/rail_config.h
@@ -33,8 +33,6 @@
 #include "rail_types.h"
 #include <stdint.h>
 
-#define RADIO_CONFIG_XTAL_FREQUENCY 38400000UL
-
 #if RADIO_CONFIG_SUBGHZ_SUPPORT
 extern const RAIL_ChannelConfig_t *channelConfigs[];
 #endif

--- a/src/src/sl_rcp_gp_interface.c
+++ b/src/src/sl_rcp_gp_interface.c
@@ -37,9 +37,9 @@
 #include "sl_packet_utils.h"
 #include "sl_rcp_gp_interface_config.h"
 #include "sl_status.h"
+#include <assert.h>
 #include <string.h>
 #include <openthread/platform/time.h>
-#include "common/debug.hpp"
 #include "common/logging.hpp"
 #include "utils/mac_frame.h"
 

--- a/src/src/soft_source_match_table.c
+++ b/src/src/soft_source_match_table.c
@@ -36,12 +36,12 @@
 
 #include "soft_source_match_table.h"
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include "common/debug.hpp"
 
 #include <openthread/logging.h>
-
+#include "common/debug.hpp"
 #include "utils/code_utils.h"
 
 // Print entire source match tables when


### PR DESCRIPTION
This updates the repo to work with the [Gecko SDK v4.4.0](https://github.com/SiliconLabs/gecko_sdk/releases/tag/v4.4.0) release

---
# Other changes

- Update scripts to install ARM GNU Toolchain 12
  - `arm-none-eabi-gcc 12` is a requirement of GSDK v4.4.0
  - Removed older toolchains from `Build` workflow
- Add ot_stack_features_config component to ot-efr32 extension
  - This adds a new component that generates a config file for `SL_OPENTHREAD_STACK_FEATURES_CONFIG_FILE`
  - This is essentially a copy of the ot_stack_ftd/mtd/rcp components except it doesn't define a `OPENTHREAD_<DEVICE_TYPE>` macro
https://github.com/SiliconLabs/gecko_sdk/blob/124fa19de8c8b3961d21c20857f7df32239786da/protocol/openthread/component/ot_stack_ftd.slcc#L21-L26
  - The component also uses the [validation script](https://github.com/SiliconLabs/gecko_sdk/blob/gsdk_4.4/protocol/openthread/component/script/ot_log_validation.lua) to ensure [`ot_rtt_log`](https://github.com/SiliconLabs/gecko_sdk/blob/gsdk_4.4/protocol/openthread/component/ot_rtt_log.slcc) is in a project if the `OPENTHREAD_CONFIG_LOG_OUTPUT` is set to `OPENTHREAD_CONFIG_LOG_PLATFORM_DEFINED`
- Update the `openthread` submodule to the head of `main`