### PR TITLE
[radio] fix connectivity issues caused by an accidental deletion in `radio.c`

### DIFF
--- a/script/build
+++ b/script/build
@@ -279,10 +279,10 @@ main()
     for t in "${OT_CMAKE_NINJA_TARGET[@]}"; do [[ $t =~ .*rcp.* ]] && rcp_targets+=("$t") || soc_targets+=("$t"); done
 
     # Build ot-rcp targets
-    if contains "ot-rcp-uart" "${rcp_targets[@]}"; then
+    if contains "ot-rcp-uart" "${rcp_targets[@]-}"; then
         build_rcp_uart -DEFR32_PLATFORM="${platform}" -DBOARD="${board}" "${options[@]}"
     fi
-    if contains "ot-rcp-spi" "${rcp_targets[@]}"; then
+    if contains "ot-rcp-spi" "${rcp_targets[@]-}"; then
         build_rcp_spi -DEFR32_PLATFORM="${platform}" -DBOARD="${board}" "${options[@]}"
     fi
     # Build soc targets

--- a/src/src/radio.c
+++ b/src/src/radio.c
@@ -1715,6 +1715,8 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
         // this results in calling the SE interface from a critical section which is not permitted.
 #if OPENTHREAD_RADIO && OPENTHREAD_CONFIG_MULTIPAN_RCP_ENABLE == 1
         radioProcessTransmitSecurity(sTxFrame, sTxFrame->mIid);
+#else
+        radioProcessTransmitSecurity(sTxFrame, 0);
 #endif
 #endif // OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
 

--- a/src/src/radio.c
+++ b/src/src/radio.c
@@ -678,10 +678,16 @@ static bool isFilterMaskValid(uint8_t mask)
     if (
         // Case 1
         ((mask & RADIO_BCAST_PANID_FILTER_MASK) || (mask & RADIO_BCAST_ADDR_FILTER_MASK)) ||
-        // Case 2
-        ((mask & 0x0F) == (mask >> 4)) ||
+        // Case 2 - Find any non-broadcast PAN ID match and get ready to compare it
+        ((((mask & (RADIO_INDEX0_PANID_FILTER_MASK | RADIO_INDEX1_PANID_FILTER_MASK | RADIO_INDEX2_PANID_FILTER_MASK))
+           >> RADIO_PANID_FILTER_SHIFT)
+          &
+          // To see if it coincides with any address matches for same IID
+          (RADIO_GET_ADDR_FILTER_MASK(mask) >> RADIO_ADDR_FILTER_SHIFT))
+         != 0)
+        ||
         // Case 3
-        (((mask & 0x0F) == 0) || ((mask >> 4) == 0)))
+        (((RADIO_GET_PANID_FILTER_MASK(mask)) == 0) || ((RADIO_GET_ADDR_FILTER_MASK(mask)) == 0)))
     {
         valid = true;
     }


### PR DESCRIPTION
[This](https://github.com/openthread/ot-efr32/pull/756/files#diff-5e9808c35ace5ab51673c2a099131b5480e0220c41bcc1ccdf5141ef5a3e25e3L1650) deletion should not have happened in `[sdk] update to GSDK 4.4.0` #756 

It caused issues with transmitting secure packets and prevented devices from joining networks.

This PR also includes a diff that was missed in #756 and a minor script fix