### PR TITLE
[script] add pre-build checks that ensure the GSDK submodule has been pulled properly

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -172,6 +172,7 @@ main()
 {
     if [ $# == 0 ]; then
         install_packages
+        install_arm_toolchain
         install_packages_pip3
         do_bootstrap_silabs
     elif [ "$1" == 'packages' ]; then

--- a/script/build
+++ b/script/build
@@ -37,6 +37,7 @@ else
 fi
 script_dir="$(realpath "$(dirname "${script_path}")")"
 repo_dir="$(dirname "${script_dir}")"
+gsdk_dir="${repo_dir}/third_party/silabs/gecko_sdk"
 
 # shellcheck source=script/efr32-definitions
 source "${repo_dir}/script/efr32-definitions"
@@ -45,6 +46,39 @@ source "${repo_dir}/script/efr32-definitions"
 source "${repo_dir}/script/util"
 
 set -euxo pipefail
+
+# ==============================================================================
+# Pre-build checks
+
+set +x
+echo "========================================================================================================="
+echo "Check if the Git LFS package is installed"
+echo "========================================================================================================="
+set -x
+if ! git lfs >/dev/null; then
+    set +x
+    echo "ERROR: Git LFS is not installed"
+    echo
+    echo "Please run './script/bootstrap packages'" to install it
+    exit 3
+fi
+
+set +x
+echo "========================================================================================================="
+echo "Ensure Git LFS has been initialized for the GSDK"
+echo "========================================================================================================="
+set -x
+if [ ! -f "$(git -C "${gsdk_dir}" rev-parse --git-dir)/hooks/pre-push" ]; then
+    git -C "${gsdk_dir}" lfs install
+fi
+
+set +x
+echo "========================================================================================================="
+echo "Ensure GSDK submodule has been initialized and LFS objects have been pulled"
+echo "========================================================================================================="
+set -x
+git submodule update --init "${gsdk_dir}"
+git -C "${gsdk_dir}" lfs pull
 
 # ==============================================================================
 OT_CMAKE_NINJA_TARGET=${OT_CMAKE_NINJA_TARGET-}
@@ -299,7 +333,7 @@ main()
             before_flags+=("--skip-generation")
         fi
 
-        "${repo_dir}"/script/build_example_apps "${before_flags[@]}" "${board}" "${after_flags[@]}" "$@"
+        "${repo_dir}"/script/build_example_apps "${before_flags[@]-}" "${board}" "${after_flags[@]-}" "$@"
 
     fi
 


### PR DESCRIPTION
This fixes the issue users run into in the scenario below.

## Problem
1. A user without `git-lfs` installed clones the repo.
2. They run `script/bootstrap` to install required packages, including `git-lfs`.
3. They run `git submodule update --init --recursive .` to init all submodules, including `third_party/silabs/gecko_sdk`
4. They attempt to build example apps `script/build <brdXXXXy>`
5. The build will fail when the linker tries linking `.a` libs from `gecko_sdk` which are lfs objects that haven't been pulled yet
```shell
$ script/build brd4151a
...
/opt/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi/bin/../lib/gcc/arm-none-eabi/12.2.1/../../../../arm-none-eabi/bin/ld:/ot-efr32/third_party/silabs/gecko_sdk/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg1_gcc_release.a: file format not recognized; treating as linker script
/opt/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi/bin/../lib/gcc/arm-none-eabi/12.2.1/../../../../arm-none-eabi/bin/ld:/ot-efr32/third_party/silabs/gecko_sdk/platform/radio/rail_lib/autogen/librail_release/librail_efr32xg1_gcc_release.a:1: syntax error
collect2: error: ld returned 1 exit status

$ cat platform/radio/rail_lib/autogen/librail_release/librail_efr32xg1_gcc_release.a
version https://git-lfs.github.com/spec/v1
oid sha256:eda0777eedcfc883cdc5ed114a60d5604b5cef71662a76214c2768f9735b154a
size 471706
```
