### PR TITLE
[github-actions] fix 'Build and push' step of docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -126,6 +126,7 @@ jobs:
         github.ref == 'refs/heads/main'
       with:
         context: .
+        file: docker/Dockerfile
         push: true
         tags: |
           ${{ env.LATEST_TAG }}


### PR DESCRIPTION
A bug was introduced in openthread/ot-efr32#793 where I moved `Dockerfile` to `docker/Dockerfile` but did not update both the build steps in the docker workflow, causing [this failure](https://github.com/SiliconLabs/ot-efr32/actions/runs/8468125501/job/23200371772#step:13:126).

This fixes the bug by specifying the new location of the Dockerfile in the `Build and push` step.