### PR TITLE
[script] simplify how platform libs are pulled into the CMake build tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,21 +64,21 @@ endif()
 # ==============================================================================
 # Set platform libs and allow overriding
 # ==============================================================================
-
 # SoC (mtd/ftd) platform library
 if(NOT OT_PLATFORM_LIB)
     set(OT_PLATFORM_LIB "openthread-efr32-soc" CACHE STRING "default efr32 SoC platform library")
 endif()
 
+# RCP platform library
 if(NOT OT_PLATFORM_LIB_RCP_SPI)
     set(OT_PLATFORM_LIB_RCP_SPI "openthread-efr32-rcp-spi" CACHE STRING "default efr32 RCP platform library")
 endif()
+
 if(NOT OT_PLATFORM_LIB_RCP_UART)
     set(OT_PLATFORM_LIB_RCP_UART "openthread-efr32-rcp-uart" CACHE STRING "default efr32 RCP platform library")
 endif()
-
-# RCP platform library
 unset(OT_PLATFORM_LIB_RCP CACHE)
+
 if(NOT OT_PLATFORM_LIB_RCP)
     if(OT_NCP_SPI)
         set(OT_PLATFORM_LIB_RCP "${OT_PLATFORM_LIB_RCP_SPI}" CACHE STRING "default efr32 RCP platform library")
@@ -92,22 +92,28 @@ set(OT_PLATFORM "external" CACHE STRING "disable example platforms" FORCE)
 # ==============================================================================
 # mbedtls
 # ==============================================================================
-# SoC mbedtls library
+# Specify a default mbedtls library if not provided
 unset(OT_EXTERNAL_MBEDTLS CACHE)
-if(NOT OT_EXTERNAL_MBEDTLS)
-    set(OT_EXTERNAL_MBEDTLS "${OT_PLATFORM_LIB}-mbedtls" CACHE STRING "external mbedtls library")
-endif()
-set(OT_MBEDTLS ${OT_EXTERNAL_MBEDTLS})
-
-# RCP mbedtls library
 unset(OT_MBEDTLS_RCP CACHE)
-if(NOT OT_MBEDTLS_RCP)
-    set(OT_MBEDTLS_RCP "${OT_PLATFORM_LIB_RCP}-mbedtls" CACHE STRING "default efr32 RCP mbedtls library")
+
+if(NOT OT_EXTERNAL_MBEDTLS)
+    if(OT_FTD OR OT_MTD)
+        # SoC mbedtls library
+        set(OT_EXTERNAL_MBEDTLS "${OT_PLATFORM_LIB}-mbedtls" CACHE STRING "external mbedtls library")
+    elseif(OT_RCP)
+        # RCP mbedtls library
+        set(OT_MBEDTLS_RCP "${OT_PLATFORM_LIB_RCP}-mbedtls" CACHE STRING "default efr32 RCP mbedtls library")
+        set(OT_EXTERNAL_MBEDTLS "${OT_MBEDTLS_RCP}" CACHE STRING "external mbedtls library")
+    endif()
 endif()
-set(OT_BUILTIN_MBEDTLS_MANAGEMENT OFF CACHE BOOL "disable builtin mbedtls management" FORCE)
+
+# If using
+if(OT_EXTERNAL_MBEDTLS)
+    set(OT_BUILTIN_MBEDTLS_MANAGEMENT OFF CACHE BOOL "disable builtin mbedtls management" FORCE)
+endif()
 
 # ==============================================================================
-# mbedtls
+# openthread
 # ==============================================================================
 # NOTE: The "openthread" subdirectory needs to be added after all OT_* variables are defined
 add_subdirectory(openthread)
@@ -125,84 +131,38 @@ target_compile_options(ot-config INTERFACE
 # ==============================================================================
 # Generated platform projects
 # ==============================================================================
-# Default library definition paths
-if(NOT RCP_SPI_DIR)
-    set(RCP_SPI_DIR     "${PROJECT_SOURCE_DIR}/build/${BOARD_LOWERCASE}/slc/rcp_spi"    CACHE STRING "Path to RCP (SPI) library definition")
-endif()
-if(NOT RCP_UART_DIR)
-    set(RCP_UART_DIR    "${PROJECT_SOURCE_DIR}/build/${BOARD_LOWERCASE}/slc/rcp_uart"   CACHE STRING "Path to RCP (UART) library definition")
-endif()
-if(NOT SOC_DIR)
-    set(SOC_DIR         "${PROJECT_SOURCE_DIR}/build/${BOARD_LOWERCASE}/slc/soc"        CACHE STRING "Path to SoC library definition")
-endif()
-
 message("OT_RCP     = ${OT_RCP}")
 message("OT_FTD     = ${OT_FTD}")
 message("OT_MTD     = ${OT_MTD}")
 message("OT_APP_RCP = ${OT_APP_RCP}")
 message("OT_APP_NCP = ${OT_APP_NCP}")
 message("OT_APP_CLI = ${OT_APP_CLI}")
+
+message("===================================================================")
+if(OT_PLATFORM_LIB_DIR)
+    message(STATUS "Using platform library from ${OT_PLATFORM_LIB_DIR}")
+    # Parse the basename of the platform library directory
+    get_filename_component(OT_PLATFORM_LIB_DIR_BASE ${OT_PLATFORM_LIB_DIR} NAME)
+
+    # Add the platform library directory
+    add_subdirectory(${OT_PLATFORM_LIB_DIR} ${PROJECT_BINARY_DIR}/${OT_PLATFORM_LIB_DIR_BASE})
+else()
+    message(FATAL_ERROR "No platform library directory found")
+endif()
+
 message("===================================================================")
 message("Using the following platform library targets:")
-
-if(OT_APP_RCP)
+if(OT_RCP)
     if(OT_NCP_SPI)
         message("-- OT_PLATFORM_LIB_RCP_SPI  = ${OT_PLATFORM_LIB_RCP_SPI}")
     else()
         message("-- OT_PLATFORM_LIB_RCP_UART = ${OT_PLATFORM_LIB_RCP_UART}")
     endif()
     message("-- OT_PLATFORM_LIB_RCP      = ${OT_PLATFORM_LIB_RCP}")
-    message("-- OT_MBEDTLS_RCP           = ${OT_MBEDTLS_RCP}")
-elseif(OT_APP_NCP OR OT_APP_CLI)
+elseif(OT_FTD OR OT_MTD)
     message("-- OT_PLATFORM_LIB          = ${OT_PLATFORM_LIB}")
-    message("-- OT_MBEDTLS               = ${OT_MBEDTLS}")
-else()
-    message("-- OT_PLATFORM_LIB          = ${OT_PLATFORM_LIB}")
-    message("-- OT_MBEDTLS               = ${OT_MBEDTLS}")
 endif()
-
-message("===================================================================")
-message("Using generated SLC projects:")
-if(OT_APP_RCP)
-    if(OT_NCP_SPI)
-        message("-- RCP_SPI_DIR  = ${RCP_SPI_DIR}")
-    else()
-        message("-- RCP_UART_DIR = ${RCP_UART_DIR}")
-    endif()
-elseif(OT_APP_NCP OR OT_APP_CLI)
-    message("-- SOC_DIR      = ${SOC_DIR}")
-endif()
-
-if(OT_APP_RCP)
-    if(OT_NCP_SPI)
-        add_subdirectory(${RCP_SPI_DIR})
-    else()
-        add_subdirectory(${RCP_UART_DIR})
-    endif()
-elseif(OT_APP_NCP OR OT_APP_CLI)
-    add_subdirectory(${SOC_DIR})
-else()
-    file(READ ${PROJECT_SOURCE_DIR}/build/${BOARD_LOWERCASE}/slc/generated_projects.txt slc_generated_projects)
-
-    # Convert file contents into a CMake list (where each element in the list
-    # is one line of the file)
-    #
-    STRING(REGEX REPLACE ";" "\\\\;" slc_generated_projects "${slc_generated_projects}")
-    STRING(REGEX REPLACE "\n" ";" slc_generated_projects "${slc_generated_projects}")
-
-    # Remove trailing empty list entry
-    STRING(REGEX REPLACE ";$" "" slc_generated_projects "${slc_generated_projects}")
-
-    foreach(slc_project IN LISTS slc_generated_projects)
-        message("Checking ${slc_project}")
-        if(EXISTS ${slc_project})
-            message("......... EXISTS")
-            add_subdirectory(${slc_project})
-        else()
-            message("......... NOT EXISTS")
-        endif()
-    endforeach()
-endif()
+message("-- OT_EXTERNAL_MBEDTLS      = ${OT_EXTERNAL_MBEDTLS}")
 message("===================================================================")
 
 

--- a/script/build
+++ b/script/build
@@ -97,8 +97,6 @@ generate()
         return
     fi
 
-    local slc_generated_projects_dir="${OT_CMAKE_BUILD_DIR}"/slc
-
     if contains ".*-(ftd|mtd)" "${OT_CMAKE_NINJA_TARGET[@]}"; then
         set +x
         echo "========================================================================================================="
@@ -148,6 +146,7 @@ build_rcp_uart()
 
     cmake \
         -GNinja \
+        -DOT_PLATFORM_LIB_DIR="${slc_generated_projects_dir}"/rcp_uart \
         -DOT_FTD=OFF \
         -DOT_MTD=OFF \
         -DOT_RCP=ON \
@@ -177,6 +176,7 @@ build_rcp_spi()
 
     cmake \
         -GNinja \
+        -DOT_PLATFORM_LIB_DIR="${slc_generated_projects_dir}"/rcp_spi \
         -DOT_FTD=OFF \
         -DOT_MTD=OFF \
         -DOT_RCP=ON \
@@ -211,6 +211,7 @@ build_soc()
 
     cmake \
         -GNinja \
+        -DOT_PLATFORM_LIB_DIR="${slc_generated_projects_dir}"/soc \
         -DOT_FTD=ON \
         -DOT_MTD=ON \
         -DOT_RCP=OFF \
@@ -295,6 +296,7 @@ main()
 
     options+=("$@")
     export OT_CMAKE_BUILD_DIR="$repo_dir/build/${board}"
+    slc_generated_projects_dir="${OT_CMAKE_BUILD_DIR}"/slc
 
     # Generate the platform libs and related libs
     if [ -n "${VENDOR_EXTENSION-}" ]; then

--- a/script/build_example_apps
+++ b/script/build_example_apps
@@ -72,91 +72,114 @@ generate()
     if [ "${skip_generation}" = true ]; then
         return
     fi
+    # Args
+    local slcp_file="${1:?Please specify a SLCP file}"
+    local generation_dir="${2:?Please specify generation directory}"
+    shift 2
 
-    local slc_generated_projects_dir="${OT_CMAKE_BUILD_DIR}"/slc
-    local cmake_library="$1"
-    shift
+    set +x
+    echo "========================================================================================================="
+    echo "Generating ${slcp_file}"
+    echo "========================================================================================================="
+    set -x
 
-    if [[ ${cmake_library} == "openthread-efr32-soc-with-buttons" ]]; then
-        set +x
-        echo "========================================================================================================="
-        echo "Generate openthread-efr32-soc-with-buttons and openthread-efr32-soc-with-buttons-mbedtls libs"
-        echo "========================================================================================================="
-        set -x
-
-        generation_dir="${slc_generated_projects_dir}/soc-with-buttons"
-        slcp="${repo_dir}/slc/platform_projects/openthread-efr32-soc-with-buttons.slcp"
-
-        "${repo_dir}/script/generate" \
-            "${slcp}" \
-            "${generation_dir}" \
-            "${board}"
-        echo "${generation_dir}" >>"${slc_generated_projects_dir}/generated_projects.txt"
-
-    elif [[ ${cmake_library} == "openthread-efr32-soc-with-buttons-power-manager" ]]; then
-        set +x
-        echo "========================================================================================================="
-        echo "Generate openthread-efr32-soc-with-buttons-power-manager and openthread-efr32-soc-with-buttons-power-manager-mbedtls libs"
-        echo "========================================================================================================="
-        set -x
-
-        generation_dir="${slc_generated_projects_dir}/soc-with-buttons-power-manager"
-        slcp="${repo_dir}/slc/platform_projects/openthread-efr32-soc-with-buttons-power-manager.slcp"
-
-        "${repo_dir}/script/generate" \
-            "${slcp}" \
-            "${generation_dir}" \
-            "${board}"
-        echo "${generation_dir}" >>"${slc_generated_projects_dir}/generated_projects.txt"
-    elif [[ ${cmake_library} == "openthread-efr32-soc-with-buttons-power-manager-csl" ]]; then
-        set +x
-        echo "========================================================================================================="
-        echo "Generate openthread-efr32-soc-with-buttons-power-manager-csl and openthread-efr32-soc-with-buttons-power-manager-csl-mbedtls libs"
-        echo "========================================================================================================="
-        set -x
-
-        generation_dir="${slc_generated_projects_dir}/soc-with-buttons-power-manager-csl"
-        slcp="${repo_dir}/slc/platform_projects/openthread-efr32-soc-with-buttons-power-manager-csl.slcp"
-
-        "${repo_dir}/script/generate" \
-            "${slcp}" \
-            "${generation_dir}" \
-            "${board}"
-        echo "${generation_dir}" >>"${slc_generated_projects_dir}/generated_projects.txt"
-    else
-        echo "ERROR: Unrecognized cmake_library: ${cmake_library}"
-        exit 4
-    fi
+    "${repo_dir}/script/generate" \
+        "${slcp_file}" \
+        "${generation_dir}" \
+        "${board}"
 }
 
 build_example_app()
 {
-    local example_app_ninja_target=${1-}
-    local ot_platform_lib=${2-}
+    set -x
+
+    # Args
+    local example_app_ninja_target="${1:?}"
+    local slcp_file="${2:?}"
     shift 2
 
+    # Parse the project name from the slcp file
+    if [ ! -f "${slcp_file}" ]; then
+        die "SLCP file not found: ${slcp_file}"
+    fi
+    local ot_platform_lib
+    ot_platform_lib=$(grep -oP '(?<=project_name: ).*' "${slcp_file}" | tr -d '\r')
+
     # Generate the platform lib and related libs
-    generate "${ot_platform_lib}"
+    local generated_ot_platform_lib_dir=${slc_generated_projects_dir}/${ot_platform_lib}
+    generate "${slcp_file}" "${generated_ot_platform_lib_dir}"
 
+    # Create the build directory
     builddir="${OT_CMAKE_BUILD_DIR}/examples/${example_app_ninja_target}"
-
     mkdir -p "${builddir}"
     cd "${builddir}"
 
+    # Configure and build the example app
+    local ot_ftd=OFF
+    if [[ ${example_app_ninja_target} == *-ftd ]]; then
+        ot_ftd=ON
+    fi
+    local ot_mtd_ssed=OFF
+    if [[ ${example_app_ninja_target} == *-mtd || ${example_app_ninja_target} == *-ssed ]]; then
+        ot_mtd_ssed=ON
+    fi
     cmake -GNinja \
         -DOT_COMPILE_WARNING_AS_ERROR=ON \
         -DOT_PLATFORM_LIB="${ot_platform_lib}" \
+        -DOT_PLATFORM_LIB_DIR="${generated_ot_platform_lib_dir}" \
         -DOT_EXTERNAL_MBEDTLS="${ot_platform_lib}-mbedtls" \
+        -DOT_RCP=OFF \
+        -DOT_FTD=${ot_ftd} \
+        -DOT_MTD=${ot_mtd_ssed} \
         -DOT_APP_CLI=OFF \
         -DOT_APP_NCP=OFF \
         -DOT_APP_RCP=OFF \
         "$@" \
         "${repo_dir}"
-
     ninja "${example_app_ninja_target}"
 
     create_srec "${builddir}"
     cd "${repo_dir}"
+}
+
+get_associated_cmake_app_option()
+{
+    local cmake_executable="${1:?Please specify a CMake executable target}"
+    case "${cmake_executable}" in
+        sleepy-demo-ftd)
+            echo "EFR32_APP_SLEEPY_DEMO_FTD"
+            ;;
+        sleepy-demo-mtd)
+            echo "EFR32_APP_SLEEPY_DEMO_MTD"
+            ;;
+        sleepy-demo-ssed)
+            echo "EFR32_APP_SLEEPY_DEMO_SSED"
+            ;;
+        *)
+            die "Unknown CMake executable: ${cmake_executable}"
+            ;;
+    esac
+}
+
+# Given a CMake executable name, return the associated SLCP file
+get_associated_slcp()
+{
+    local cmake_executable="${1:?Please specify a CMake executable target}"
+
+    case "${cmake_executable}" in
+        sleepy-demo-ftd)
+            echo "${repo_dir}/slc/platform_projects/openthread-efr32-soc-with-buttons.slcp"
+            ;;
+        sleepy-demo-mtd)
+            echo "${repo_dir}/slc/platform_projects/openthread-efr32-soc-with-buttons-power-manager.slcp"
+            ;;
+        sleepy-demo-ssed)
+            echo "${repo_dir}/slc/platform_projects/openthread-efr32-soc-with-buttons-power-manager-csl.slcp"
+            ;;
+        *)
+            die "Unknown CMake executable: ${cmake_executable}"
+            ;;
+    esac
 }
 
 main()
@@ -221,22 +244,23 @@ main()
 
     options+=("$@")
     export OT_CMAKE_BUILD_DIR="$repo_dir/build/${board}"
+    slc_generated_projects_dir="${OT_CMAKE_BUILD_DIR}"/slc
 
-    build_example_app sleepy-demo-ftd openthread-efr32-soc-with-buttons \
-        -DEFR32_PLATFORM="${platform}" -DBOARD="${board}" "${options[@]}" -DEFR32_APP_SLEEPY_DEMO_FTD=ON
-    build_example_app sleepy-demo-mtd openthread-efr32-soc-with-buttons-power-manager \
-        -DEFR32_PLATFORM="${platform}" -DBOARD="${board}" "${options[@]}" -DEFR32_APP_SLEEPY_DEMO_MTD=ON
-    build_example_app sleepy-demo-ssed openthread-efr32-soc-with-buttons-power-manager-csl \
-        -DEFR32_PLATFORM="${platform}" -DBOARD="${board}" "${options[@]}" -DEFR32_APP_SLEEPY_DEMO_SSED=ON
+    # If no target is specified, build all targets
+    if [ -z "${OT_CMAKE_NINJA_TARGET}" ]; then
+        OT_CMAKE_NINJA_TARGET=(sleepy-demo-ftd sleepy-demo-mtd sleepy-demo-ssed)
+    fi
 
-    apps=(
-        sleepy-demo-ftd
-        sleepy-demo-mtd
-        sleepy-demo-ssed
-    )
-    for app in "${apps[@]}"; do
-        if [ -d "${OT_CMAKE_BUILD_DIR}"/examples/"${app}" ]; then
-            ls -alh "${OT_CMAKE_BUILD_DIR}"/examples/"${app}"/bin/*
+    # Build the example apps
+    for target in "${OT_CMAKE_NINJA_TARGET[@]}"; do
+        build_example_app "${target}" "$(get_associated_slcp "${target}")" \
+            -DEFR32_PLATFORM="${platform}" -DBOARD="${board}" "${options[@]}" -D"$(get_associated_cmake_app_option "${target}")"=ON
+    done
+
+    # List the built binaries
+    for target in "${OT_CMAKE_NINJA_TARGET[@]}"; do
+        if [ -d "${OT_CMAKE_BUILD_DIR}"/examples/"${target}" ]; then
+            ls -alh "${OT_CMAKE_BUILD_DIR}"/examples/"${target}"/bin/*
         fi
     done
 }

--- a/script/efr32-definitions
+++ b/script/efr32-definitions
@@ -35,9 +35,16 @@ if [[ -n ${BASH_SOURCE[0]} ]]; then
 else
     script_path="$0"
 fi
-script_dir="$(realpath "$(dirname "${script_path}")")"
-repo_dir="$(dirname "${script_dir}")"
-sdk_dir="${repo_dir}/third_party/silabs/gecko_sdk"
+
+# Check if repo_dir is defined
+if [ -z ${repo_dir+x} ]; then
+    script_dir="$(realpath "$(dirname "${script_path}")")"
+    repo_dir="$(dirname "${script_dir}")"
+fi
+# Check if gsdk_dir is defined
+if [ -z ${gsdk_dir+x} ]; then
+    gsdk_dir="${repo_dir}/third_party/silabs/gecko_sdk"
+fi
 
 efr32_device_regex=""
 efr32_device_regex+="\(efr32\)*"                               # Group 1 - efr32 (optional)
@@ -69,7 +76,7 @@ efr32_get_board_slcc()
     # Find component file for latest revision of board
     local board_slcc
     board_slcc=$(
-        find "${sdk_dir}"/hardware/board/component -type f \( -name "${board}*" ! -name '*_support.slcc' \) \
+        find "${gsdk_dir}"/hardware/board/component -type f \( -name "${board}*" ! -name '*_support.slcc' \) \
             | sort --version-sort \
             | tail -n 1
     )


### PR DESCRIPTION
Minor script improvements and also minor changes to the CMakeLists.txt file that make it easier for ot-efr32 to be consumed by a different project