### PR TITLE
[script] leverage `slc` SDK cache and add `ccache` to speedup incremental builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,12 @@ jobs:
         with:
           submodules: true
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ matrix.gcc_ver }}
+          verbose: 2
+
       - name: Create LFS file hash list
         run: git -C third_party/silabs/gecko_sdk lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
 
@@ -94,7 +100,14 @@ jobs:
         run: docker load -i ot-efr32-dev.tar
 
       - name: Start ot-efr32-dev container
-        run: docker run --rm -it --user $(id -u) --name ot-efr32-dev -d -v $PWD:/ot-efr32 -w /ot-efr32 ${{ env.DOCKER_IMAGE_SHA_TAG }}
+        run: |
+          docker run \
+            --rm -it -d \
+            --user $(id -u) \
+            --name ot-efr32-dev \
+            --env CCACHE_DIR=/ot-efr32/.ccache \
+            -v $PWD:/ot-efr32 -w /ot-efr32\
+            ${{ env.DOCKER_IMAGE_SHA_TAG }}
 
       - name: Bootstrap ARM Toolchain
         run: docker exec ot-efr32-dev script/bootstrap arm_toolchain ${{ matrix.gcc_download_url }} ${{ matrix.gcc_extract_dir }} ${{ env.TOOLCHAIN_DIR }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,23 +78,15 @@ jobs:
           key: ${{ matrix.gcc_ver }}
           verbose: 2
 
-      - name: Append LFS include config to GSDK .lfsconfig
-        run: |
-          git -C third_party/silabs/gecko_sdk checkout -- .lfsconfig
-          echo 'fetchinclude = "platform/emdrv/nvm3/lib/libnvm3_*_gcc.a,platform/radio/rail_lib/autogen/librail_release/librail_config_mgm*_gcc.a,platform/radio/rail_lib/autogen/librail_release/*efr32xg*_gcc_release.a"' >> third_party/silabs/gecko_sdk/.lfsconfig
-
-      - name: Create LFS file hash list
-        run: git -C third_party/silabs/gecko_sdk lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
-
-      - name: Restore gecko_sdk LFS cache
+      - name: Restore ARM Toolchain
         uses: actions/cache@v4
-        id: lfs-cache
+        id: cache-arm-toolchain
         with:
-            path: .git/modules/third_party/silabs/gecko_sdk/lfs
-            key: lfs-${{ hashFiles('.lfs-assets-id') }}
+            path: ${{ env.TOOLCHAIN_DIR }}/${{ matrix.gcc_extract_dir }}
+            key: ${{ matrix.gcc_extract_dir }}
 
-      - name: Git LFS Pull
-        run: git -C third_party/silabs/gecko_sdk lfs pull
+      - name: Bootstrap ARM Toolchain
+        run: script/bootstrap arm_toolchain ${{ matrix.gcc_download_url }} ${{ matrix.gcc_extract_dir }} ${{ env.TOOLCHAIN_DIR }}
 
       - name: Download Docker image
         uses: actions/download-artifact@v4
@@ -114,8 +106,23 @@ jobs:
             -v $PWD:/ot-efr32 -w /ot-efr32\
             ${{ env.DOCKER_IMAGE_SHA_TAG }}
 
-      - name: Bootstrap ARM Toolchain
-        run: docker exec ot-efr32-dev script/bootstrap arm_toolchain ${{ matrix.gcc_download_url }} ${{ matrix.gcc_extract_dir }} ${{ env.TOOLCHAIN_DIR }}
+      - name: Append LFS include config to GSDK .lfsconfig
+        run: |
+          git -C third_party/silabs/gecko_sdk checkout -- .lfsconfig
+          echo 'fetchinclude = "platform/emdrv/nvm3/lib/libnvm3_*_gcc.a,platform/radio/rail_lib/autogen/librail_release/librail_config_mgm*_gcc.a,platform/radio/rail_lib/autogen/librail_release/*efr32xg*_gcc_release.a"' >> third_party/silabs/gecko_sdk/.lfsconfig
+
+      - name: Create LFS file hash list
+        run: git -C third_party/silabs/gecko_sdk lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Restore gecko_sdk LFS cache
+        uses: actions/cache@v4
+        id: lfs-cache-gecko_gsdk
+        with:
+            path: .git/modules/third_party/silabs/gecko_sdk/lfs
+            key: lfs-${{ hashFiles('.lfs-assets-id') }}
+
+      - name: Git LFS Pull
+        run: git -C third_party/silabs/gecko_sdk lfs pull
 
       - name: Build
         run: docker exec ot-efr32-dev bash -c 'PATH=${{ env.TOOLCHAIN_DIR }}/${{ matrix.gcc_extract_dir }}/bin:$PATH script/test'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,11 @@ jobs:
           key: ${{ matrix.gcc_ver }}
           verbose: 2
 
+      - name: Append LFS include config to GSDK .lfsconfig
+        run: |
+          git -C third_party/silabs/gecko_sdk checkout -- .lfsconfig
+          echo 'fetchinclude = "platform/emdrv/nvm3/lib/libnvm3_*_gcc.a,platform/radio/rail_lib/autogen/librail_release/librail_config_mgm*_gcc.a,platform/radio/rail_lib/autogen/librail_release/*efr32xg*_gcc_release.a"' >> third_party/silabs/gecko_sdk/.lfsconfig
+
       - name: Create LFS file hash list
         run: git -C third_party/silabs/gecko_sdk lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -48,6 +48,7 @@ install_packages_apt()
     # Install dependencies
     sudo apt-get update
     apt_packages=(
+        ccache
         coreutils
         git
         git-lfs
@@ -77,6 +78,7 @@ install_packages_brew()
     echo 'Installing script dependencies...'
 
     brew_packages=(
+        ccache
         coreutils
         git
         git-lfs

--- a/script/build
+++ b/script/build
@@ -89,6 +89,12 @@ OT_OPTIONS=(
     "-DOT_EXTERNAL_HEAP=ON"
     "-DOT_SLAAC=ON"
 )
+
+# Check if ccache is installed and use it if available
+if command -v ccache >/dev/null; then
+    OT_OPTIONS+=("-DCMAKE_C_COMPILER_LAUNCHER=ccache")
+    OT_OPTIONS+=("-DCMAKE_CXX_COMPILER_LAUNCHER=ccache")
+fi
 readonly OT_OPTIONS
 
 generate()

--- a/script/build_example_apps
+++ b/script/build_example_apps
@@ -59,6 +59,12 @@ OT_OPTIONS=(
     "-DOT_PING_SENDER=ON"
     "-DOT_SLAAC=ON"
 )
+
+# Check if ccache is installed and use it if available
+if command -v ccache >/dev/null; then
+    OT_OPTIONS+=("-DCMAKE_C_COMPILER_LAUNCHER=ccache")
+    OT_OPTIONS+=("-DCMAKE_CXX_COMPILER_LAUNCHER=ccache")
+fi
 readonly OT_OPTIONS
 
 die()

--- a/script/generate
+++ b/script/generate
@@ -91,7 +91,7 @@ trust_sdk_and_extensions()
     set -x
 
     # Trust the Gecko SDK submodule
-    run_slc -v 1 signature trust --sdk "${sdk_dir}" -data "${openthread_slc_data}"
+    run_slc --daemon -v 1 signature trust --sdk "${sdk_dir}" -data "${openthread_slc_data}"
 
     # Ensure GSDK extension folder exists
     mkdir -p "${sdk_dir}/extension"
@@ -138,7 +138,7 @@ trust_sdk_and_extensions()
         fi
 
         # Trust the extension
-        run_slc -v 1 signature trust --sdk "${sdk_dir}" -extpath "${extension_symlink}" -data "${openthread_slc_data}"
+        run_slc --daemon -v 1 signature trust --sdk "${sdk_dir}" -extpath "${extension_symlink}" -data "${openthread_slc_data}"
     done
 
     ls -alh "${sdk_dir}/extension"
@@ -215,10 +215,9 @@ generate()
     echo "======================================================================"
     set -x
 
-    run_slc -v 1 generate \
+    run_slc --daemon -v 1 generate \
         -data "${openthread_slc_data?}" \
         --sdk="${sdk_dir?}" \
-        --clear-cache \
         --project-file="${slcp}" \
         --project-name="${project_name}" \
         --output-type=makefile \


### PR DESCRIPTION
# Summary of changes
- `slc`
  - Remove the `--clear-cache` flag to leverage SDK cache
  - Switch to using daemon-mode. Reduces `slc` startup time
- Add [`ccache`](https://ccache.dev/) to build scripts for potential build speedups. See more below
- GitHub Actions
  - Only pull required LFS files
  - Cache ARM Toolchain between builds

---

# [CCache](https://ccache.dev/)

When building with no compiler cache, the build proceeds as normal and takes a normal amount of time. For the `Build/arm-gcc-*` workflows, it usually takes ~20-30 min for the workflow to run completely. 

**Example:** `Build/arm-gcc-12.2.Rel1` (no compiler cache)

> If you examine [this](https://github.com/SiliconLabs/ot-efr32/actions/runs/9308159746/job/25620968130?pr=723) run, you can see during the setup, there's no cache found [(log here)](https://github.com/SiliconLabs/ot-efr32/actions/runs/9308159746/job/25620968130?pr=723#step:5:14). Looking at the [`ccache` statistics](https://github.com/SiliconLabs/ot-efr32/actions/runs/9308159746/job/25620968130?pr=723#step:24:11) during teardown, you can see there was a very low cache hit rate.
> 
> `ccache` hits: **2.05 %**
> Time spent in `Build` step: **22m 22s**

**Example:** `Build/arm-gcc-12.2.Rel1` (with compiler cache)

> During this second run, [a compiler cache was located](https://github.com/SiliconLabs/ot-efr32/actions/runs/9308127890/job/25620883929?pr=723#step:5:17) and added to the workspace.  This speedup is also reflected in the [`ccache` statistics](https://github.com/SiliconLabs/ot-efr32/actions/runs/9308127890/job/25620883929?pr=723#step:24:11).
> 
> `ccache` hits: **99.46 %**
> Time spent in `Build` step: **2m 52s**

These performance gains are not limited to GitHub actions builds. CCache has been added to the `script/build` and `script/build-example-apps` scripts, meaning builds on development machines will also benefit from the same speedup potential.

One thing to note is that `ccache` will bring the most benefit when iterating on changes. Of course, the speedup will be reduced in scenarios where the cache cannot be leveraged, including but not limited to the first build when building for a board you haven't built before, switching branches, or making any wide-reaching changes.