### PR TITLE
dont use gnu specific grep

### DIFF
--- a/script/generate
+++ b/script/generate
@@ -117,7 +117,8 @@ trust_sdk_and_extensions()
 
         # Parse extension name
         local extension_name=""
-        extension_name=$(grep -oP '^id: \K(.*)' "${slce_file}")
+        extension_line=$(grep -m 1 'id: ' "${slce_file}")
+        extension_name="$(echo ${extension_line//id:/})"
 
         # Define symlink location
         local extension_symlink="${sdk_dir}/extension/${extension_name}"
@@ -174,7 +175,8 @@ generate()
     # Define generation variables
     local slcp=${1?A .slcp file is expected as the first argument}
     local project_name=""
-    project_name=$(grep -oP 'project_name: \K(.*)' "${slcp}")
+    project_line=$(grep 'project_name: ' "${slcp}")
+    project_name="$(echo ${project_line//project_name:/})"
     local generation_dir=${2?A generation output dir is expected as the second argument}
     local export_templates="${repo_dir}/slc/exporter_templates/platform_library"
     local board=${3?A board is expected as the third argument}

--- a/script/util
+++ b/script/util
@@ -107,4 +107,3 @@ parse_configuration()
     if [[ -n $old_setting ]]; then set -e; else set +e; fi
 
 }
-

--- a/script/util
+++ b/script/util
@@ -85,10 +85,14 @@ parse_configuration()
     old_setting=${-//[^e]/}
     set +e
     # grep raw values from the configuration file
-    rcp_uart_slcp="$(grep -oP 'rcp_uart_slcp: \K(.*)' "${config_yml}")"
-    rcp_spi_slcp="$(grep -oP 'rcp_spi_slcp: \K(.*)' "${config_yml}")"
-    soc_slcp="$(grep -oP 'soc_slcp: \K(.*)' "${config_yml}")"
-    board="$(grep -oP 'board: \K(.*)' "${config_yml}")"
+    line="$(grep 'rcp_uart_slcp:' "${config_yml}")"
+    rcp_uart_slcp="$(echo $line//rcp_uart_slcp:/)"
+    line="$(grep 'rcp_spi_slcp:' "${config_yml}")"
+    rcp_spi_slcp="$(echo $line//rcp_spi_slcp:/)"
+    line="$(grep 'soc_slcp:' "${config_yml}")"
+    soc_slcp="$(echo $line//soc_slcp:/)"
+    line="$(grep 'board:' "${config_yml}")"
+    board="$(echo $line//board:/)"
 
     # Strip quotes
     rcp_uart_slcp=$(eval echo "${rcp_uart_slcp}")
@@ -103,3 +107,4 @@ parse_configuration()
     if [[ -n $old_setting ]]; then set -e; else set +e; fi
 
 }
+

--- a/script/util
+++ b/script/util
@@ -105,5 +105,4 @@ parse_configuration()
     rcp_spi_slcp="${extension_dir}/${rcp_spi_slcp#./}"
     soc_slcp="${extension_dir}/${soc_slcp#./}"
     if [[ -n $old_setting ]]; then set -e; else set +e; fi
-
 }


### PR DESCRIPTION
grep -oP is specific to GNU versions of grep which aren't (any longer) used on Mac/OSX platforms.  The use in scripts is a bit overkill for just getting a token. This replaces grep with bash-native parsing
