### PR TITLE
Use regular (not Perl) grep syntax in scripts

### DIFF
--- a/script/generate
+++ b/script/generate
@@ -178,7 +178,7 @@ generate()
     local project_name=""
     project_line=$(grep 'project_name: ' "${slcp}")
     project_name="${project_line//project_name:/}"
-    project_name="${project_line// /}"
+    project_name="${project_name// /}"
     local generation_dir=${2?A generation output dir is expected as the second argument}
     local export_templates="${repo_dir}/slc/exporter_templates/platform_library"
     local board=${3?A board is expected as the third argument}

--- a/script/generate
+++ b/script/generate
@@ -117,7 +117,8 @@ trust_sdk_and_extensions()
 
         # Parse extension name
         local extension_name=""
-        extension_name=$(grep -oP '^id: \K(.*)' "${slce_file}")
+        extension_line=$(grep -m 1 'id: ' "${slce_file}")
+        extension_name="$(echo ${extension_line//id:/})"
 
         # Define symlink location
         local extension_symlink="${sdk_dir}/extension/${extension_name}"
@@ -174,7 +175,8 @@ generate()
     # Define generation variables
     local slcp=${1?A .slcp file is expected as the first argument}
     local project_name=""
-    project_name=$(grep -oP 'project_name: \K(.*)' "${slcp}")
+    project_line=$(grep 'project_name: ' "${slcp}")
+    project_name="$(echo ${project_line//project_name:/})"
     local generation_dir=${2?A generation output dir is expected as the second argument}
     local export_templates="${repo_dir}/slc/exporter_templates/platform_library"
     local board=${3?A board is expected as the third argument}

--- a/script/generate
+++ b/script/generate
@@ -119,6 +119,7 @@ trust_sdk_and_extensions()
         local extension_name=""
         extension_line=$(grep -m 1 'id: ' "${slce_file}")
         extension_name="${extension_line//id:/}"
+        extension_name="${extension_name// /}"
 
         # Define symlink location
         local extension_symlink="${sdk_dir}/extension/${extension_name}"
@@ -177,6 +178,7 @@ generate()
     local project_name=""
     project_line=$(grep 'project_name: ' "${slcp}")
     project_name="${project_line//project_name:/}"
+    project_name="${project_line// /}"
     local generation_dir=${2?A generation output dir is expected as the second argument}
     local export_templates="${repo_dir}/slc/exporter_templates/platform_library"
     local board=${3?A board is expected as the third argument}

--- a/script/generate
+++ b/script/generate
@@ -118,7 +118,7 @@ trust_sdk_and_extensions()
         # Parse extension name
         local extension_name=""
         extension_line=$(grep -m 1 'id: ' "${slce_file}")
-        extension_name="$(echo ${extension_line//id:/})"
+        extension_name="${extension_line//id:/}"
 
         # Define symlink location
         local extension_symlink="${sdk_dir}/extension/${extension_name}"
@@ -176,7 +176,7 @@ generate()
     local slcp=${1?A .slcp file is expected as the first argument}
     local project_name=""
     project_line=$(grep 'project_name: ' "${slcp}")
-    project_name="$(echo ${project_line//project_name:/})"
+    project_name="${project_line//project_name:/}"
     local generation_dir=${2?A generation output dir is expected as the second argument}
     local export_templates="${repo_dir}/slc/exporter_templates/platform_library"
     local board=${3?A board is expected as the third argument}

--- a/script/util
+++ b/script/util
@@ -86,13 +86,13 @@ parse_configuration()
     set +e
     # grep raw values from the configuration file
     line="$(grep 'rcp_uart_slcp:' "${config_yml}")"
-    rcp_uart_slcp="$(echo $line//rcp_uart_slcp:/)"
+    rcp_uart_slcp="${line//rcp_uart_slcp:/}"
     line="$(grep 'rcp_spi_slcp:' "${config_yml}")"
-    rcp_spi_slcp="$(echo $line//rcp_spi_slcp:/)"
+    rcp_spi_slcp="${line//rcp_spi_slcp:/}"
     line="$(grep 'soc_slcp:' "${config_yml}")"
-    soc_slcp="$(echo $line//soc_slcp:/)"
+    soc_slcp="${line//soc_slcp:/}"
     line="$(grep 'board:' "${config_yml}")"
-    board="$(echo $line//board:/)"
+    board="${line//board:/}"
 
     # Strip quotes
     rcp_uart_slcp=$(eval echo "${rcp_uart_slcp}")

--- a/script/util
+++ b/script/util
@@ -107,4 +107,3 @@ parse_configuration()
     if [[ -n $old_setting ]]; then set -e; else set +e; fi
 
 }
-

--- a/script/util
+++ b/script/util
@@ -85,10 +85,14 @@ parse_configuration()
     old_setting=${-//[^e]/}
     set +e
     # grep raw values from the configuration file
-    rcp_uart_slcp="$(grep -oP 'rcp_uart_slcp: \K(.*)' "${config_yml}")"
-    rcp_spi_slcp="$(grep -oP 'rcp_spi_slcp: \K(.*)' "${config_yml}")"
-    soc_slcp="$(grep -oP 'soc_slcp: \K(.*)' "${config_yml}")"
-    board="$(grep -oP 'board: \K(.*)' "${config_yml}")"
+    line="$(grep 'rcp_uart_slcp:' "${config_yml}")"
+    rcp_uart_slcp="$(echo $line//rcp_uart_slcp:/)"
+    line="$(grep 'rcp_spi_slcp:' "${config_yml}")"
+    rcp_spi_slcp="$(echo $line//rcp_spi_slcp:/)"
+    line="$(grep 'soc_slcp:' "${config_yml}")"
+    soc_slcp="$(echo $line//soc_slcp:/)"
+    line="$(grep 'board:' "${config_yml}")"
+    board="$(echo $line//board:/)"
 
     # Strip quotes
     rcp_uart_slcp=$(eval echo "${rcp_uart_slcp}")
@@ -103,3 +107,4 @@ parse_configuration()
     if [[ -n $old_setting ]]; then set -e; else set +e; fi
 
 }
+

--- a/script/util
+++ b/script/util
@@ -94,6 +94,12 @@ parse_configuration()
     line="$(grep 'board:' "${config_yml}")"
     board="${line//board:/}"
 
+    # Strip spaces
+    rcp_uart_slcp="${rcp_uart_slcp// /}"
+    rcp_spi_slcp="${rcp_spi_slcp// /}"
+    soc_slcp="${soc_slcp// /}"
+    board="${board// /}"
+
     # Strip quotes
     rcp_uart_slcp=$(eval echo "${rcp_uart_slcp}")
     rcp_spi_slcp=$(eval echo "${rcp_spi_slcp}")


### PR DESCRIPTION
Mac platforms are become more locked-down and when grep is installed
by XCode for example it is a BSD version not GNU version so doesn't
have the "-P" option to use perl patterns.  This fixes scripts to not
depend on GNU grep.