### PR TITLE
[github-actions] move DockerHub publish job into a separate workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,10 +40,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.repository == 'openthread/ot-efr32' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
-env:
-  TOOLCHAIN_DIR: .toolchain
-  DOCKER_IMAGE_SHA_TAG: siliconlabsinc/ot-efr32-dev:${{ github.sha }}
-
 jobs:
   docker:
     name: Docker
@@ -52,10 +48,13 @@ jobs:
   arm-gcc:
     name: Arm GNU Toolchain ${{ matrix.gcc_ver }}
     runs-on: ubuntu-22.04
-    needs: docker
+    needs: [docker]
     continue-on-error: true
     permissions:
       contents: read
+    env:
+      container_name: ot-efr32-dev
+      TOOLCHAIN_DIR: .toolchain
     strategy:
       fail-fast: false
       matrix:
@@ -91,20 +90,20 @@ jobs:
       - name: Download Docker image
         uses: actions/download-artifact@v4
         with:
-          name: ot-efr32-dev
+          name: ${{ needs.docker.outputs.artifact_name }}
 
       - name: Load docker image
-        run: docker load -i ot-efr32-dev.tar
+        run: docker load -i ${{ needs.docker.outputs.image_name }}.tar
 
       - name: Start ot-efr32-dev container
         run: |
           docker run \
             --rm -it -d \
             --user $(id -u) \
-            --name ot-efr32-dev \
+            --name ${{ env.container_name }} \
             --env CCACHE_DIR=/ot-efr32/.ccache \
             -v $PWD:/ot-efr32 -w /ot-efr32\
-            ${{ env.DOCKER_IMAGE_SHA_TAG }}
+            ${{ needs.docker.outputs.image_name }}
 
       - name: Append LFS include config to simplicity_sdk .lfsconfig
         run: |
@@ -125,7 +124,7 @@ jobs:
         run: git -C third_party/silabs/simplicity_sdk lfs pull
 
       - name: Build
-        run: docker exec ot-efr32-dev bash -c 'PATH=${{ env.TOOLCHAIN_DIR }}/${{ matrix.gcc_extract_dir }}/bin:$PATH script/test'
+        run: docker exec ${{ env.container_name }} bash -c 'PATH=${{ env.TOOLCHAIN_DIR }}/${{ matrix.gcc_extract_dir }}/bin:$PATH script/test'
 
       - name: Gather SLC generated files
         if: failure()
@@ -144,3 +143,16 @@ jobs:
         with:
           name: build-${{ matrix.gcc_ver }}
           path: artifact
+
+  dockerhub-publish:
+    name: DockerHub Publish
+    uses: ./.github/workflows/dockerhub-publish.yml
+    needs: [docker, arm-gcc]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'SiliconLabs'
+    with:
+      artifact_name: ${{ needs.docker.outputs.artifact_name }}
+      image_name: ${{ needs.docker.outputs.image_name }}
+      new_image_name: siliconlabsinc/ot-efr32-dev:latest
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,12 +28,19 @@
 
 name: Docker
 
+env:
+  artifact_name: ot-efr32-dev
+  image_name: ot-efr32-dev-${{ github.sha }}
+
 on:
   workflow_call:
-
-env:
-  DOCKER_IMAGE_SHA_TAG: siliconlabsinc/ot-efr32-dev:${{ github.sha }}
-  DOCKER_IMAGE_LATEST_TAG: siliconlabsinc/ot-efr32-dev:latest
+    outputs:
+      artifact_name:
+        description: 'The name of the artifact containing the docker image'
+        value: ${{ jobs.build.outputs.artifact_name }}
+      image_name:
+        description: 'The name of the docker image'
+        value: ${{ jobs.build.outputs.image_name}}
 
 jobs:
   metadata:
@@ -45,6 +52,9 @@ jobs:
     needs: metadata
     permissions:
       contents: read
+    outputs:
+      artifact_name: ${{ env.artifact_name }}
+      image_name: ${{ env.image_name }}
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
@@ -69,12 +79,12 @@ jobs:
         file: docker/Dockerfile
         load: true
         tags: |
-          ${{ env.DOCKER_IMAGE_SHA_TAG }}
+          ${{ env.image_name }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
     - name: Inspect Docker image
-      run: docker inspect ${{ env.DOCKER_IMAGE_SHA_TAG }}
+      run: docker inspect ${{ env.image_name }}
 
     - name: Container image sanity checks
       run: |
@@ -83,45 +93,14 @@ jobs:
           && chmod +x container-structure-test-linux-amd64
 
         # Run tests
-        ./container-structure-test-linux-amd64 test --config docker/test-ot-efr32-dev.yml --image ${{ env.DOCKER_IMAGE_SHA_TAG }}
+        ./container-structure-test-linux-amd64 test --config docker/test-ot-efr32-dev.yml --image ${{ env.image_name }}
 
     - name: Export Docker image
-      run: docker save -o ot-efr32-dev.tar ${{ env.DOCKER_IMAGE_SHA_TAG }}
+      run: docker save -o ${{ env.image_name }}.tar ${{ env.image_name }}
 
     - name: Upload Docker image
+      id: upload-artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ot-efr32-dev
-        path: ot-efr32-dev.tar
-
-  publish-dockerhub:
-    name: Tag `latest` and publish to DockerHub
-    runs-on: ubuntu-22.04
-    needs: [metadata, build]
-    if: |
-      github.repository == 'SiliconLabs/ot-efr32' &&
-      github.event_name != 'pull_request' &&
-      github.ref == 'refs/heads/main'
-    steps:
-      - name: Login to DockerHub
-        if: github.ref == 'refs/heads/main'
-        uses: docker/login-action@v3.3.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Download Docker image
-        uses: actions/download-artifact@v4
-        with:
-          name: ot-efr32-dev
-
-      - name: Load Docker image
-        run: docker load -i ot-efr32-dev.tar
-
-      - name: Tag Docker image
-        run: |
-          docker tag ${{ env.DOCKER_IMAGE_SHA_TAG }} ${{ env.DOCKER_IMAGE_LATEST_TAG }}
-
-      - name: Push Docker image
-        run: |
-          docker push ${{ env.DOCKER_IMAGE_LATEST_TAG }}
+        name: ${{ env.artifact_name }}
+        path: ${{ env.image_name }}.tar

--- a/.github/workflows/dockerhub-publish.yml
+++ b/.github/workflows/dockerhub-publish.yml
@@ -1,0 +1,76 @@
+#
+#  Copyright (c) 2024, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+name: Download docker image artifact and publish to DockerHub
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: 'The name of the artifact containing the docker image'
+        type: string
+        required: true
+      image_name:
+        description: 'The name of the docker image'
+        type: string
+        required: true
+      new_image_name:
+        description: 'The new name of the docker image'
+        type: string
+        required: false
+    secrets:
+      DOCKERHUB_USERNAME:
+        description: 'DockerHub username'
+      DOCKERHUB_PERSONAL_ACCESS_TOKEN:
+        description: 'DockerHub personal access token'
+
+jobs:
+  publish:
+    name: Tag `latest` and publish to DockerHub
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v3.3.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}
+
+      - name: 'Download artifact'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name }}
+
+      - name: Load Docker image
+        run: docker load -i ${{ inputs.image_name }}.tar
+
+      - name: Tag Docker image
+        if: inputs.new_image_name
+        run: docker tag ${{ inputs.image_name }} ${{ inputs.new_image_name }}
+
+      - name: Push Docker image
+        run: docker push ${{ inputs.new_image_name || inputs.image_name }}


### PR DESCRIPTION
Also, this fixes the bug where the DockerHub username and password secrets are unavailable in the DockerHub login step.

[This failure](https://github.com/SiliconLabs/ot-efr32/actions/runs/9681942492/job/26713977695) is caused by a bug I accidentally introduced in https://github.com/openthread/ot-efr32/pull/896. The secrets consumed by a reusable workflow must be defined as inputs.

See this for more details
https://docs.github.com/en/actions/sharing-automations/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow