### PR TITLE
[doc][cmake] update series 1 references to series 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,14 +164,3 @@ elseif(OT_FTD OR OT_MTD)
 endif()
 message("-- OT_EXTERNAL_MBEDTLS      = ${OT_EXTERNAL_MBEDTLS}")
 message("===================================================================")
-
-
-# efr32mg12 Sub-GHz support
-set(EFR32MG12_915MHZ_PHY_SOURCES
-    ${PROJECT_SOURCE_DIR}/src/efr32mg12/phy/PHY_IEEE802154_915MHZ_OQPSK_EFR32XG12.c
-    ${PROJECT_SOURCE_DIR}/src/efr32mg12/phy/PHY_IEEE802154_915MHZ_2GFSK_EFR32XG12.c
-)
-string(COMPARE EQUAL "${PLATFORM_LOWERCASE}" "efr32mg12" _cmp)
-if (_cmp AND TARGET ${OT_PLATFORM_LIB})
-    target_sources(${OT_PLATFORM_LIB} PUBLIC ${EFR32MG12_915MHZ_PHY_SOURCES})
-endif()

--- a/examples/example_vendor_slc_extension/component/my_custom_board.slcc
+++ b/examples/example_vendor_slc_extension/component/my_custom_board.slcc
@@ -38,7 +38,7 @@ description: This is an example component that adds vendor-specific sources
 provides:
   - name: my_custom_board
 requires:
-  - efr32mg1p232f256gm48
+  - efr32mg24b210f1536im48
 
 # Set the root path for all relative paths in this component.
 # The value of root_path is relative to the root of this repo

--- a/examples/example_vendor_slc_extension/config.yml
+++ b/examples/example_vendor_slc_extension/config.yml
@@ -27,7 +27,7 @@
 #
 
 # Target board
-board: brd4161a
+board: brd4186c
 
 # SLCP locations
 # NOTE: These paths are relative to the extension's root dir

--- a/examples/sleepy-demo/README.md
+++ b/examples/sleepy-demo/README.md
@@ -10,11 +10,11 @@ For setting up the build environment refer to [OpenThread on EFR32](../../src/RE
 
 ## 1. Build
 
-In this `README`, all example commands will be targeting the `brd4161a` board on the `efr32mg12` platform. The same commands should work for the other boards
+In this `README`, all example commands will be targeting the `brd4186c` board on the `efr32mg24` platform. The same commands should work for the other boards
 
 ```bash
 $ cd <path-to-ot-efr32>
-$ board="brd4161a"
+$ board="brd4186c"
 $ ./script/build $board
 ```
 
@@ -22,7 +22,7 @@ The build script will convert the resulting executables into S-Record format and
 
 ```bash
 $ ls build/$board/bin/sleepy*
-build/brd4161a/bin/sleepy-demo-ftd  build/brd4161a/bin/sleepy-demo-ftd.s37  build/brd4161a/bin/sleepy-demo-mtd  build/brd4161a/bin/sleepy-demo-mtd.s37
+build/brd4186c/bin/sleepy-demo-ftd  build/brd4186c/bin/sleepy-demo-ftd.s37  build/brd4186c/bin/sleepy-demo-mtd  build/brd4186c/bin/sleepy-demo-mtd.s37
 ```
 
 In Silicon Labs Simplicity Studio flash one device with the `sleepy-demo-mtd.s37` image and the other device with the `sleepy-demo-ftd.s37` image.

--- a/src/README.md
+++ b/src/README.md
@@ -79,12 +79,12 @@ Before building example apps, make sure to initialize all submodules. Afterward,
 
 **Example**
 
-The example below demonstrates how to build for `efr32mg12` on `brd4161a`, but the same command maybe used for other platforms and boards.
+The example below demonstrates how to build for `efr32mg24` on `brd4186c`, but the same command maybe used for other platforms and boards.
 
 ```bash
 $ cd <path-to-ot-efr32>
 $ git submodule update --init --recursive .
-$ board="brd4161a"
+$ board="brd4186c"
 $ ./script/build $board
 ...
 -- Configuring done
@@ -175,12 +175,12 @@ Compiled binaries also may be flashed onto the specified EFR32 dev board using [
 
 [j-link-commander]: https://www.segger.com/products/debug-probes/j-link/tools/j-link-commander/
 
-**Example:** Flashing `ot-cli-ftd` to a `brd4161a` device
+**Example:** Flashing `ot-cli-ftd` to a `brd4186c` device
 
 ```bash
 $ cd <path-to-ot-efr32>
 $ source ./script/efr32-definitions
-$ board="brd4161a"
+$ board="brd4186c"
 $ cd <path-to-ot-efr32>/build/$board/bin
 $ arm-none-eabi-objcopy -O ihex ot-cli-ftd ot-cli-ftd.hex
 $ <path-to-JLinkGDBServer>/JLinkExe -device $(efr32_get_jlink_device $board) -speed 4000 -if SWD -autoconnect 1 -SelectEmuBySN <SerialNo>
@@ -313,11 +313,11 @@ A debug session may be started with [J-LinkGDBServer][jlinkgdbserver].
 
 [jlinkgdbserver]: https://www.segger.com/jlink-gdb-server.html
 
-**Example:** Debugging `ot-cli-ftd` on a `brd4161a` device
+**Example:** Debugging `ot-cli-ftd` on a `brd4186c` device
 
 ```bash
 $ source <path-to-ot-efr32>/script/efr32-definitions
-$ board="brd4161a"
+$ board="brd4186c"
 $ cd <path-to-JLinkGDBServer>
 $ sudo ./JLinkGDBServer -if swd -singlerun -device $(efr32_get_jlink_device $board)
 $ cd <path-to-ot-efr32>/build/$board/bin
@@ -334,11 +334,11 @@ $ (gdb) c
 
 The above example demonstrates basic OpenThread capabilities. Enable more features/roles (e.g. commissioner, joiner, DHCPv6 Server/Client, etc.) by assigning compile-options before compiling.
 
-**Example** Building efr32mg12 for board `brd4161a` with some more features/roles enabled
+**Example** Building efr32mg24 for board `brd4186c` with some more features/roles enabled
 
 ```bash
 $ cd <path-to-ot-efr32>
-$ ./script/build brd4161a -DOT_COMMISSIONER=ON -DOT_JOINER=ON -DOT_DHCP6_CLIENT=ON -DOT_DHCP6_SERVER=ON
+$ ./script/build brd4186c -DOT_COMMISSIONER=ON -DOT_JOINER=ON -DOT_DHCP6_CLIENT=ON -DOT_DHCP6_SERVER=ON
 ```
 
 <a name="verification"/>


### PR DESCRIPTION
This fixes some leftovers I missed from https://github.com/openthread/ot-efr32/pull/918

---

# Changes
 - Replace `brd4161a` with `brd4186c` in all documentation
 - Remove `efr32mg12` subghz support logic from top-level `CMakeLists.txt`