### PR TITLE
[script] fix incorrect package name for brew bootstrap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -83,7 +83,7 @@ install_packages_brew()
         git
         git-lfs
         grep
-        ninja-build
+        ninja
         openjdk@17
         unzip
         wget


### PR DESCRIPTION
`ninja` is the correct brew package name for the Ninja build system
https://formulae.brew.sh/formula/ninja