### PR TITLE
[github] set puppeteer executable path for linkspector

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -66,6 +66,8 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: umbrelladocs/action-linkspector@963b6264d7de32c904942a70b488d3407453049e # v1.5.1
+      env:
+        PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
       with:
         github_token: ${{ secrets.github_token }}
         fail_level: error


### PR DESCRIPTION
This commit updates the `markdown-lint-check` job to explicitly set the `PUPPETEER_EXECUTABLE_PATH` environment variable to use the system-installed Google Chrome (`/usr/bin/google-chrome`) for the `linkspector` action. This resolves issues where the action fails to find a browser environment to execute properly.