### PR TITLE
[github-actions] bump docker/login-action to v4.6.0 & pin SHAs

### DIFF
--- a/.github/workflows/dockerhub-publish.yml
+++ b/.github/workflows/dockerhub-publish.yml
@@ -55,13 +55,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Login to DockerHub
-        uses: docker/login-action@v4.5.1
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}
 
       - name: 'Download artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ inputs.artifact_name }}
 
@@ -78,4 +78,7 @@ jobs:
           INPUTS_NEW_IMAGE_NAME: ${{ inputs.new_image_name }}
 
       - name: Push Docker image
-        run: docker push ${{ inputs.new_image_name || inputs.image_name }}
+        run: docker push ${INPUTS_NEW_IMAGE_NAME:-$INPUTS_IMAGE_NAME}
+        env:
+          INPUTS_IMAGE_NAME: ${{ inputs.image_name }}
+          INPUTS_NEW_IMAGE_NAME: ${{ inputs.new_image_name }}


### PR DESCRIPTION
Bump docker/login-action to v4.6.0.

Fix zizmor security findings in dockerhub-publish.yml:
- Pin docker/login-action and actions/download-artifact to full commit SHA hashes.
- Use environment variables for docker push to prevent template injection risks.