### PR TITLE
[github-actions] pin actions to commit SHA hashes in dockerhub-publish

### DIFF
--- a/.github/workflows/dockerhub-publish.yml
+++ b/.github/workflows/dockerhub-publish.yml
@@ -55,13 +55,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Login to DockerHub
-        uses: docker/login-action@v4.5.1
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}
 
       - name: 'Download artifact'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ inputs.artifact_name }}
 
@@ -78,4 +78,6 @@ jobs:
           INPUTS_NEW_IMAGE_NAME: ${{ inputs.new_image_name }}
 
       - name: Push Docker image
-        run: docker push ${{ inputs.new_image_name || inputs.image_name }}
+        run: docker push ${IMAGE_NAME}
+        env:
+          IMAGE_NAME: ${{ inputs.new_image_name || inputs.image_name }}


### PR DESCRIPTION
Pin docker/login-action and actions/download-artifact to full commit SHA hashes in dockerhub-publish.yml. Also update docker/login-action to v4.6.0.

Referencing GitHub Actions by version tags triggers unpinned-uses errors in zizmor security scans during CI workflows. Pinning to full commit SHAs resolves these security scan failures and allows Dependabot to maintain commit SHA references for future updates.