### PR TITLE
[github-actions] pin action references to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.repository == 'openthread/ot-efr32' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     name: Docker
@@ -72,13 +75,13 @@ jobs:
           submodules: true
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639 # v1.2.20
         with:
           key: ${{ matrix.gcc_ver }}
           verbose: 2
 
       - name: Restore ARM Toolchain
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: cache-arm-toolchain
         with:
             path: ${{ env.TOOLCHAIN_DIR }}/${{ matrix.gcc_extract_dir }}
@@ -88,7 +91,7 @@ jobs:
         run: script/bootstrap arm_toolchain ${{ matrix.gcc_download_url }} ${{ matrix.gcc_extract_dir }} ${{ env.TOOLCHAIN_DIR }}
 
       - name: Download Docker image
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ needs.docker.outputs.artifact_name }}
 
@@ -118,7 +121,7 @@ jobs:
         run: git -C third_party/silabs/simplicity_sdk lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
 
       - name: Restore simplicity_sdk LFS cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: lfs-cache-simplicity_sdk
         with:
             path: .git/modules/third_party/silabs/simplicity_sdk/lfs
@@ -142,7 +145,7 @@ jobs:
               mv "build/${board}/slc" "artifact/${board}"
           done
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: build-${{ matrix.gcc_ver }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,6 +40,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.repository == 'openthread/ot-efr32' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   pretty:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,6 +42,9 @@ on:
         description: 'The name of the docker image'
         value: ${{ jobs.build.outputs.image_name}}
 
+permissions:
+  contents: read
+
 jobs:
   metadata:
     uses: ./.github/workflows/metadata.yml
@@ -71,7 +74,7 @@ jobs:
         platforms: linux/amd64
 
     - name: Build and export to Docker context
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         build-args: |
           BUILD_DATE=${{ needs.metadata.outputs.date }}
@@ -106,7 +109,7 @@ jobs:
 
     - name: Upload Docker image
       id: upload-artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ env.artifact_name }}
         path: ${{ env.image_name }}.tar

--- a/.github/workflows/dockerhub-publish.yml
+++ b/.github/workflows/dockerhub-publish.yml
@@ -49,6 +49,9 @@ on:
       DOCKERHUB_PERSONAL_ACCESS_TOKEN:
         description: 'DockerHub personal access token'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Tag `latest` and publish to DockerHub

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -38,6 +38,9 @@ on:
         description: 'The current date'
         value: ${{ jobs.metadata.outputs.date }}
 
+permissions:
+  contents: read
+
 jobs:
   metadata:
     name: Generate required metadata


### PR DESCRIPTION
Pin action references across GitHub Actions workflows to full commit SHA hashes to satisfy the zizmor unpinned-uses security policy:
- build.yml: pin hendrikmuhs/ccache-action (v1.2.20), actions/cache (v6.1.0), actions/download-artifact (v8.0.1), and actions/upload-artifact (v7.0.1).
- docker.yml: pin docker/build-push-action (v7.3.0) and actions/upload-artifact (v7.0.1).