### PR TITLE
submodule: bump openthread from `a900427` to `a93706f`

### DIFF
--- a/src/src/ieee802154-packet-utils.cpp
+++ b/src/src/ieee802154-packet-utils.cpp
@@ -338,10 +338,7 @@ otPanId efr32GetDstPanId(otRadioFrame *aFrame)
 {
     otPanId aPanId = 0xFFFF;
 
-    if (static_cast<Mac::RxFrame *>(aFrame)->IsDstPanIdPresent())
-    {
-        static_cast<Mac::RxFrame *>(aFrame)->GetDstPanId(aPanId);
-    }
+    IgnoreError(static_cast<Mac::RxFrame *>(aFrame)->GetDstPanId(aPanId));
 
     return aPanId;
 }
@@ -360,12 +357,7 @@ uint8_t *efr32GetPayload(otRadioFrame *aFrame)
     return result;
 }
 
-bool efr32FrameIsPanIdCompressed(otRadioFrame *aFrame)
-{
-    return static_cast<Mac::RxFrame *>(aFrame)->IsPanIdCompressed();
-}
-
 uint16_t efr32GetFrameVersion(otRadioFrame *aFrame)
 {
-    return static_cast<Mac::RxFrame *>(aFrame)->GetVersion();
+    return static_cast<uint16_t>(static_cast<Mac::RxFrame *>(aFrame)->GetVersion()) << 12;
 }

--- a/src/src/sl_packet_utils.h
+++ b/src/src/sl_packet_utils.h
@@ -81,15 +81,6 @@ otPanId efr32GetDstPanId(otRadioFrame *aFrame);
 uint8_t *efr32GetPayload(otRadioFrame *aFrame);
 
 /**
- * This function checks if the PAN ID Compression bit is set in the given MAC frame.
- *
- * @param[in]  aFrame       A pointer to the MAC frame buffer.
- *
- * @return true if the PAN ID Compression bit is set, false otherwise.
- */
-bool efr32FrameIsPanIdCompressed(otRadioFrame *aFrame);
-
-/**
  * This function returns the frame version.
  *
  * @param[in]  aFrame       A pointer to the MAC frame buffer.


### PR DESCRIPTION
Bumps openthread from `a900427` to `a93706f` and updates EFR32 packet utilities for breaking `Mac::Frame` API changes:
- OpenThread PR #13515 removed `IsDstPanIdPresent()` and `IsPanIdCompressed()` from `Mac::Frame`.
- OpenThread PR #13516 changed `Mac::Frame::GetVersion()` to return an unshifted 2-bit version value (`uint8_t`) instead of the shifted FCF version bits (`uint16_t`).

Updates `ieee802154-packet-utils.cpp` and `sl_packet_utils.h`:
- In `efr32GetDstPanId()`, call `GetDstPanId()` directly.
- Remove unused `efr32FrameIsPanIdCompressed()`.
- In `efr32GetFrameVersion()`, left-shift `GetVersion()` by 12 bits to preserve the shifted FCF version field expected by callers.